### PR TITLE
Don't show timesteps with NaNs in data availability plot

### DIFF
--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -233,7 +233,7 @@ class Plots:
     def _data_availability(series, names=None, intervals=None,
                            ignore=('second', 'minute', '14 days'),
                            normtype='log', cmap='viridis_r',
-                           set_yticks=False, figsize=(10, 8), 
+                           set_yticks=False, figsize=(10, 8),
                            dropna=True, **kwargs):
         """Plot the data-availability for a list of timeseries.
 

--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -202,7 +202,9 @@ class Plots:
         figsize : tuple, optional
             The size of the new figure in inches (h,v)
         progressbar : bool
-            show progressbar
+            Show progressbar
+        dropna : bool
+            Do not show NaNs as available data
         kwargs : dict, optional
             Extra arguments are passed to matplotlib.pyplot.subplots()
 
@@ -260,7 +262,9 @@ class Plots:
         figsize : tuple, optional
             The size of the new figure in inches (h,v)
         progressbar : bool
-            show progressbar
+            Show progressbar
+        dropna : bool
+            Do not show NaNs as available data
         kwargs : dict, optional
             Extra arguments are passed to matplotlib.pyplot.subplots()
 

--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -176,7 +176,7 @@ class Plots:
                           ignore=('second', 'minute', '14 days'),
                           normtype='log', cmap='viridis_r',
                           set_yticks=False, figsize=(10, 8),
-                          progressbar=True, **kwargs):
+                          progressbar=True, dropna=True, **kwargs):
         """Plot the data-availability for multiple timeseries in pastastore.
 
         Parameters
@@ -226,14 +226,15 @@ class Plots:
         ax = self._data_availability(series, names=names, intervals=intervals,
                                      ignore=ignore, normtype=normtype,
                                      cmap=cmap, set_yticks=set_yticks,
-                                     figsize=figsize, **kwargs)
+                                     figsize=figsize, dropna=dropna, **kwargs)
         return ax
 
     @staticmethod
     def _data_availability(series, names=None, intervals=None,
                            ignore=('second', 'minute', '14 days'),
                            normtype='log', cmap='viridis_r',
-                           set_yticks=False, figsize=(10, 8), **kwargs):
+                           set_yticks=False, figsize=(10, 8), 
+                           dropna=True, **kwargs):
         """Plot the data-availability for a list of timeseries.
 
         Parameters
@@ -298,6 +299,8 @@ class Plots:
 
         for i, s in enumerate(series):
             if not s.empty:
+                if dropna:
+                    s = s.dropna()
                 pc = ax.pcolormesh(s.index, [i, i + 1],
                                    [np.diff(s.index).astype(float)],
                                    norm=norm, cmap=cmap,


### PR DESCRIPTION
If there are NaNs in the timeseries they count as "available data" in the data availability plot. 

For example, the data availability now looks as:
![dropnafalse](https://user-images.githubusercontent.com/66305055/144410807-0e34f4b9-0d6f-4254-9f28-0dc24de31416.png)
Life looks good, there seem to be no gaps in the data. However, that is because the timesteps with no data contain NaNs.

Dropping these NaNs shows a more realistic figure of the actual data availability:
![dropnatrue](https://user-images.githubusercontent.com/66305055/144410811-23b39eb6-6bd5-478f-9d9a-d16f3f6a51a9.png)

This PR adds the option `dropna` to the function `pastastore.plots.data_availability()`. Default is `dropna=True`.