### PR TITLE
add oseries models accessor

### DIFF
--- a/pastastore/connectors.py
+++ b/pastastore/connectors.py
@@ -8,7 +8,8 @@ from typing import Dict, Optional, Union
 import pandas as pd
 from pastas.io.pas import PastasEncoder, pastas_hook
 
-from .base import BaseConnector, ConnectorUtil, ModelAccessor
+from .base import (BaseConnector, ConnectorUtil,
+                   ModelAccessor, OseriesModelsAccessor)
 from .util import _custom_warning
 
 FrameorSeriesUnion = Union[pd.DataFrame, pd.Series]
@@ -46,6 +47,7 @@ class ArcticConnector(BaseConnector, ConnectorUtil):
         self.arc = arctic.Arctic(connstr)
         self._initialize()
         self.models = ModelAccessor(self)
+        self.oseries_models = OseriesModelsAccessor(self)
 
     def _initialize(self) -> None:
         """Internal method to initalize the libraries."""
@@ -212,6 +214,7 @@ class PystoreConnector(BaseConnector, ConnectorUtil):
         self.libs: dict = {}
         self._initialize()
         self.models = ModelAccessor(self)
+        self.oseries_models = OseriesModelsAccessor(self)
 
     def _initialize(self) -> None:
         """Internal method to initalize the libraries (stores)."""
@@ -405,6 +408,7 @@ class DictConnector(BaseConnector, ConnectorUtil):
         for val in self._default_library_names:
             setattr(self, "lib_" + val, {})
         self.models = ModelAccessor(self)
+        self.oseries_models = OseriesModelsAccessor(self)
 
     def _get_library(self, libname: str):
         """Get reference to dictionary holding data.
@@ -539,6 +543,7 @@ class PasConnector(BaseConnector, ConnectorUtil):
         self.path = os.path.abspath(path)
         self._initialize()
         self.models = ModelAccessor(self)
+        self.oseries_models = OseriesModelsAccessor(self)
 
     def _initialize(self) -> None:
         """Internal method to initialize the libraries."""

--- a/pastastore/store.py
+++ b/pastastore/store.py
@@ -97,6 +97,10 @@ class PastaStore:
     def n_models(self):
         return self.conn.n_models
 
+    @property
+    def oseries_models(self):
+        return self.conn.oseries_models
+
     def __repr__(self):
         """Representation string of the object."""
         return f"<PastaStore> {self.name}: \n - " + self.conn.__str__()
@@ -869,39 +873,3 @@ class PastaStore:
             return structure.dropna(how="all", axis=1)
         else:
             return structure
-
-    def get_oseries_model_list(self,
-                               modelnames: Optional[Union[list, str]] = None,
-                               progressbar: bool = True) -> Dict:
-        """Get a list of model names for each oseries.
-
-        Parameters
-        ----------
-        modelnames : Optional[Union[list, str]], optional
-            list of modelnames to consider, by default None, which
-            defaults to all models
-        progressbar : bool, optional
-            show progressbar, by default False
-
-        Returns
-        -------
-        oseries_model_dict : dict
-            dictionary with oseries names as keys, and list of model names
-            as values
-        """
-
-        modelnames = self.conn._parse_names(modelnames, libname="models")
-
-        oseries_model_dict = {}
-
-        for mlnam in (tqdm(modelnames, desc="Get model oseries names")
-                      if progressbar else modelnames):
-            iml = self.get_models(mlnam, returndict=True)
-            oname = iml["oseries"]["name"]
-            if oname in oseries_model_dict:
-                oseries_model_dict[oname] = oseries_model_dict[oname].append(
-                    oname)
-            else:
-                oseries_model_dict[oname] = [oname]
-
-        return oseries_model_dict

--- a/tests/test_003_pastastore.py
+++ b/tests/test_003_pastastore.py
@@ -82,15 +82,37 @@ def test_model_accessor(request, pstore):
     # getter
     ml = pstore.models["oseries1"]
     # setter
-    pstore.models["oseries2"] = ml
+    pstore.models["oseries1_2"] = ml
     # iter
     mnames = [ml.name for ml in pstore.models]
     try:
         assert len(mnames) == 2
-        assert mnames[0] in ["oseries1", "oseries2"]
-        assert mnames[1] in ["oseries1", "oseries2"]
+        assert mnames[0] in ["oseries1", "oseries1_2"]
+        assert mnames[1] in ["oseries1", "oseries1_2"]
     finally:
-        pstore.del_models("oseries2")
+        pstore.del_models("oseries1_2")
+    return
+
+
+@pytest.mark.dependency()
+def test_oseries_model_accessor(request, pstore):
+    depends(request, [f"test_store_model[{pstore.type}]"])
+    # repr
+    pstore.oseries_models.__repr__()
+    # get model names
+    ml = pstore.models["oseries1"]
+    ml_list1 = pstore.oseries_models["oseries1"]
+    assert len(ml_list1) == 1
+
+    # add model
+    pstore.models["oseries1_2"] = ml
+    ml_list2 = pstore.oseries_models["oseries1"]
+    assert len(ml_list2) == 2
+
+    # delete model
+    pstore.del_models("oseries1_2")
+    ml_list3 = pstore.oseries_models["oseries1"]
+    assert len(ml_list3) == 1
     return
 
 


### PR DESCRIPTION
- keep a list of model names per oseries
- list is updated when models are added deleted
- accessor has dict-like access
- initialized when instantiating connector (2 ms per model for arctic)
- add test

e.g.
```python
pstore.oseries_models
# Returns:
# {"oseries1" : ["model1", "model2"], "oseries2": ["model3"]}

pstore.oseries_models["oseries1"]
# Returns:
# ["model1", "model2"]
```