### PR TITLE
Plot option for cumulative histogram

### DIFF
--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -329,7 +329,7 @@ class Plots:
         return ax
 
     def cumulative_hist(self, statistic='rsq', modelnames=None,
-                        dummy=False, ax=None, figsize=(6, 6),
+                        extend=False, ax=None, figsize=(6, 6),
                         label=None, legend=True):
         """Plot a cumulative step histogram for a model statistic.
 
@@ -337,12 +337,13 @@ class Plots:
         ----------
         statistic: str
             name of the statistic, e.g. "evp" or "rmse", by default "rsq"
-        modelnames : list of str, optional
+        modelnames: list of str, optional
             modelnames to plot statistic for, by default None, which
             uses all models in the store
-        dummy : bool, optional
-            add a dummy value to remove ugly line, by default False, if 
-            True the results are skewed, esp. if number of models is low
+        extend: bool, optional
+            force extend the stats Series with a dummy value to move the
+            horizontal line outside figure bounds. If True the results 
+            are skewed a bit, especially if number of models is low.
         ax: matplotlib.Axes, optional
             axes to plot histogram, by default None which creates an Axes
         figsize: tuple, optional
@@ -369,32 +370,33 @@ class Plots:
             ax.set_xlim(0, 1)
             ax.set_ylabel(statistic)
             ax.set_xlabel('Density')
+            ax.set_title('Cumulative Step Histogram')
         if statistic == 'evp':
             ax.set_yticks(np.linspace(0, 100, 11))
-            if dummy:
+            if extend:
                 statsdf = statsdf.append(
                     pd.Series(100, index=['dummy']))
                 ax.set_ylim(0, 100)
             else:
                 ax.set_ylim(0, statsdf.max())
-        elif statistic == 'rsq':
+        elif statistic in ('rsq', 'nse', 'kge_2012'):
             ax.set_yticks(np.linspace(0, 1, 11))
-            if dummy:
+            if extend:
                 statsdf = statsdf.append(
                     pd.Series(1, index=['dummy']))
                 ax.set_ylim(0, 1)
             else:
                 ax.set_ylim(0, statsdf.max())
-        elif statistic == 'aic' or statistic == 'bic':
+        elif statistic in ('aic', 'bic'):
             ax.set_ylim(statsdf.min(), statsdf.max())
         else:
-            if dummy:
+            if extend:
                 statsdf = statsdf.append(
                     pd.Series(0, index=['dummy']))
             ax.set_ylim(0, statsdf.max())
-        
+
         if label == None:
-            if dummy:
+            if extend:
                 label = f'No. Models = {len(statsdf)-1}'
             else:
                 label = f'No. Models = {len(statsdf)}'
@@ -402,7 +404,7 @@ class Plots:
         statsdf.hist(ax=ax, bins=len(statsdf), density=True,
                      cumulative=True, histtype='step',
                      orientation='horizontal', label=label)
-        
+
         if legend:
             ax.legend(loc=4)
 

--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -328,6 +328,86 @@ class Plots:
         f.tight_layout(pad=0.0)
         return ax
 
+    def cumulative_hist(self, statistic='rsq', modelnames=None,
+                        dummy=False, ax=None, figsize=(6, 6),
+                        label=None, legend=True):
+        """Plot a cumulative step histogram for a model statistic.
+
+        Parameters
+        ----------
+        statistic: str
+            name of the statistic, e.g. "evp" or "rmse", by default "rsq"
+        modelnames : list of str, optional
+            modelnames to plot statistic for, by default None, which
+            uses all models in the store
+        dummy : bool, optional
+            add a dummy value to remove ugly line, by default False, if 
+            True the results are skewed, esp. if number of models is low
+        ax: matplotlib.Axes, optional
+            axes to plot histogram, by default None which creates an Axes
+        figsize: tuple, optional
+            figure size, by default (6,6)
+        label: str, optional
+            label for the legend, by default None, which shows the number 
+            of models
+        legend: bool, optional
+            show legend, by default True
+
+        Returns
+        -------
+        ax : matplotlib Axes
+            The axes in which the cumulative histogram is plotted
+        """
+
+        statsdf = self.pstore.get_statistics([statistic],
+                                             modelnames=modelnames,
+                                             progressbar=False)
+
+        if ax == None:
+            _, ax = plt.subplots(1, 1, figsize=figsize)
+            ax.set_xticks(np.linspace(0, 1, 11))
+            ax.set_xlim(0, 1)
+            ax.set_ylabel(statistic)
+            ax.set_xlabel('Density')
+        if statistic == 'evp':
+            ax.set_yticks(np.linspace(0, 100, 11))
+            if dummy:
+                statsdf = statsdf.append(
+                    pd.Series(100, index=['dummy']))
+                ax.set_ylim(0, 100)
+            else:
+                ax.set_ylim(0, statsdf.max())
+        elif statistic == 'rsq':
+            ax.set_yticks(np.linspace(0, 1, 11))
+            if dummy:
+                statsdf = statsdf.append(
+                    pd.Series(1, index=['dummy']))
+                ax.set_ylim(0, 1)
+            else:
+                ax.set_ylim(0, statsdf.max())
+        elif statistic == 'aic' or statistic == 'bic':
+            ax.set_ylim(statsdf.min(), statsdf.max())
+        else:
+            if dummy:
+                statsdf = statsdf.append(
+                    pd.Series(0, index=['dummy']))
+            ax.set_ylim(0, statsdf.max())
+        
+        if label == None:
+            if dummy:
+                label = f'No. Models = {len(statsdf)-1}'
+            else:
+                label = f'No. Models = {len(statsdf)}'
+
+        statsdf.hist(ax=ax, bins=len(statsdf), density=True,
+                     cumulative=True, histtype='step',
+                     orientation='horizontal', label=label)
+        
+        if legend:
+            ax.legend(loc=4)
+
+        return ax
+
 
 class Maps:
     """Map Class for PastaStore.


### PR DESCRIPTION
This is an option to plot a cumulative histogram of the model results using:
`ax = pstore.plots.cumulative_hist('evp')`

![Cumulative_Histogram](https://user-images.githubusercontent.com/66305055/159489393-5bdcbc48-2fc3-4fde-85ea-b6b16a330c5f.png)

There is one little caveat when using the option `dummy=True`. This add a dummy variable to remove the ugly horizontal line but this skews the line a little bit. Default is thus `dummy=False`, but I wanted to include it because the results look better.