### PR TITLE
Automated Label Placement

### DIFF
--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -974,11 +974,11 @@ class Maps:
 
             texts = []
             for name, row in df.iterrows():
-                texts.append(ax.text(row['x'], row['y'], str(name),
-                                     **{'path_effects': stroke}))
+                texts.append(ax.text(row['x'], row['y'], name,
+                                     **{"path_effects": stroke}))
 
-            adjust_text(texts, force_text=0.05, arrowprops=dict(
-                arrowstyle='-', color='k', alpha=0.5))
+            adjust_text(texts, force_text=0.05, **{'arrowprops':
+                        {'arrowstyle': '-', 'color': 'k', 'alpha': 0.5}})
 
         else:
             fontsize = kwargs.pop("fontsize", 10)

--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -976,12 +976,11 @@ class Maps:
             for name, row in df.iterrows():
                 texts.append(ax.text(row['x'], row['y'], str(name),
                                      **{'path_effects': stroke}))
+
             adjust_text(texts, force_text=0.05, arrowprops=dict(
                 arrowstyle='-', color='k', alpha=0.5))
 
         else:
-            stroke = [patheffects.withStroke(linewidth=3, foreground="w")]
-
             fontsize = kwargs.pop("fontsize", 10)
             textcoords = kwargs.pop("textcoords", "offset points")
             xytext = kwargs.pop("xytext", (10, 10))

--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -24,6 +24,7 @@ from matplotlib.collections import LineCollection
 from matplotlib.colors import BoundaryNorm, LogNorm
 from matplotlib.lines import Line2D
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from adjustText import adjust_text
 
 
 class Plots:
@@ -384,6 +385,7 @@ class Plots:
             if extend:
                 statsdf = statsdf.append(
                     pd.Series(1, index=['dummy']))
+                statsdf[statsdf < 0] = 0
                 ax.set_ylim(0, 1)
             else:
                 ax.set_ylim(0, statsdf.max())
@@ -434,7 +436,7 @@ class Maps:
         """
         self.pstore = pstore
 
-    def stresses(self, kind=None, labels=True, figsize=(10, 8), **kwargs):
+    def stresses(self, kind=None, labels=True, adjust=False, figsize=(10, 8), **kwargs):
         """Plot stresses locations on map.
 
         Parameters
@@ -444,6 +446,8 @@ class Maps:
             which plots all stresses.
         labels: bool, optional
             label models, by default True
+        adjust: bool, optional
+            automated smart label placement using adjustText, by default False
         figsize: tuple, optional
             figure size, by default(10, 8)
 
@@ -468,17 +472,19 @@ class Maps:
         ax = self._plotmap_dataframe(stresses.loc[mask0], figsize=figsize,
                                      **kwargs)
         if labels:
-            self.add_labels(stresses, ax)
+            self.add_labels(stresses, ax, adjust=adjust)
 
         return ax
 
-    def oseries(self, labels=True, figsize=(10, 8), **kwargs):
+    def oseries(self, labels=True, adjust=False, figsize=(10, 8), **kwargs):
         """Plot oseries locations on map.
 
         Parameters
         ----------
         labels: bool, optional
             label models, by default True
+        adjust: bool, optional
+            automated smart label placement using adjustText, by default False
         figsize: tuple, optional
             figure size, by default(10, 8)
 
@@ -496,17 +502,19 @@ class Maps:
         ax = self._plotmap_dataframe(oseries.loc[mask0], figsize=figsize,
                                      **kwargs)
         if labels:
-            self.add_labels(oseries, ax)
+            self.add_labels(oseries, ax, adjust=adjust)
 
         return ax
 
-    def models(self, labels=True, figsize=(10, 8), **kwargs):
+    def models(self, labels=True, adjust=False, figsize=(10, 8), **kwargs):
         """Plot model locations on map.
 
         Parameters
         ----------
         labels: bool, optional
             label models, by default True
+        adjust: bool, optional
+            automated smart label placement using adjustText, by default False
         figsize: tuple, optional
             figure size, by default(10, 8)
 
@@ -531,12 +539,12 @@ class Maps:
         ax = self._plotmap_dataframe(models.loc[mask0], figsize=figsize,
                                      **kwargs)
         if labels:
-            self.add_labels(models, ax)
+            self.add_labels(models, ax, adjust=adjust)
 
         return ax
 
-    def modelstat(self, statistic, label=True, cmap="viridis", norm=None,
-                  vmin=None, vmax=None, figsize=(10, 8), **kwargs):
+    def modelstat(self, statistic, label=True, adjust=False, cmap="viridis", 
+                  norm=None, vmin=None, vmax=None, figsize=(10, 8), **kwargs):
         """Plot model statistic on map.
 
         Parameters
@@ -545,6 +553,8 @@ class Maps:
             name of the statistic, e.g. "evp" or "aic"
         label: bool, optional
             label points, by default True
+        adjust: bool, optional
+            automated smart label placement using adjustText, by default False
         cmap: str or colormap, optional
             (name of) the colormap, by default "viridis"
         norm: norm, optional
@@ -590,7 +600,7 @@ class Maps:
                                      **scatter_kwargs)
         if label:
             df.set_index("index", inplace=True)
-            self.add_labels(df, ax)
+            self.add_labels(df, ax, adjust=adjust)
         return ax
 
     @staticmethod
@@ -800,7 +810,8 @@ class Maps:
         return ax
 
     def stresslinks(self, kinds=None, model_names=None, color_lines=False,
-                    alpha=0.4, figsize=(10, 8), legend=True, labels=False):
+                    alpha=0.4, figsize=(10, 8), legend=True, labels=False,
+                    adjust=False):
         """Create a map linking models with their stresses.
 
         Parameters
@@ -822,7 +833,9 @@ class Maps:
             legend: bool, optional
                 create a legend for all unique kinds, defaults to True.
             labels: bool, optional
-                add labels for stresses, defaults to False.
+                add labels for stresses and oseries, defaults to False.
+            adjust: bool, optional
+                automated smart label placement using adjustText, by default False
         Returns
         -------
         ax: axes object
@@ -865,7 +878,8 @@ class Maps:
                                      [st.loc[s, 'x'], st.loc[s, 'y']]])
                     segment_colors.append(color)
                     if labels:
-                        self.add_labels(st, ax)
+                        self.add_labels(os, ax, adjust=adjust)
+                        self.add_labels(st, ax, adjust=adjust)
 
         ax.scatter([x[1][0] for x in segments],
                    [y[1][1] for y in segments],
@@ -938,7 +952,7 @@ class Maps:
                         **kwargs)
 
     @staticmethod
-    def add_labels(df, ax, **kwargs):
+    def add_labels(df, ax, adjust=False, **kwargs):
         """Add labels to points on plot.
 
         Uses dataframe index to label points.
@@ -949,21 +963,33 @@ class Maps:
             DataFrame containing x, y - data. Index is used as label
         ax: matplotlib.Axes
             axes object to label points on
+        adjust: bool
+            automated smart label placement using adjustText
         **kwargs:
             keyword arguments to ax.annotate
         """
-
         stroke = [patheffects.withStroke(linewidth=3, foreground="w")]
 
-        fontsize = kwargs.pop("fontsize", 10)
-        textcoords = kwargs.pop("textcoords", "offset points")
-        xytext = kwargs.pop("xytext", (10, 10))
+        if adjust:
+            texts = []
+            for name, row in df.iterrows():
+                texts.append(ax.text(row['x'], row['y'], str(name),
+                                     **{'path_effects': stroke}))
+            adjust_text(texts, force_text=0.05, arrowprops=dict(
+                arrowstyle='-', color='k', alpha=0.5))
 
-        for name, row in df.iterrows():
-            namestr = str(name)
-            txt = ax.annotate(text=namestr,
-                              xy=(row["x"], row["y"]),
-                              fontsize=fontsize,
-                              textcoords=textcoords,
-                              xytext=xytext)
-            txt.set_path_effects(stroke)
+        else:
+            stroke = [patheffects.withStroke(linewidth=3, foreground="w")]
+
+            fontsize = kwargs.pop("fontsize", 10)
+            textcoords = kwargs.pop("textcoords", "offset points")
+            xytext = kwargs.pop("xytext", (10, 10))
+
+            for name, row in df.iterrows():
+                namestr = str(name)
+                ax.annotate(text=namestr,
+                            xy=(row["x"], row["y"]),
+                            fontsize=fontsize,
+                            textcoords=textcoords,
+                            xytext=xytext,
+                            **{"path_effects": stroke})

--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -24,7 +24,6 @@ from matplotlib.collections import LineCollection
 from matplotlib.colors import BoundaryNorm, LogNorm
 from matplotlib.lines import Line2D
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from adjustText import adjust_text
 
 
 class Plots:
@@ -971,6 +970,8 @@ class Maps:
         stroke = [patheffects.withStroke(linewidth=3, foreground="w")]
 
         if adjust:
+            from adjustText import adjust_text
+
             texts = []
             for name, row in df.iterrows():
                 texts.append(ax.text(row['x'], row['y'], str(name),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.15
-pandas>=1.0,<1.2.0
+pandas>=1.0,<1.2.0  # note 1.1.5 necessary for Arctic for now
 tqdm>=4.36
 pastas>=0.13.0
 contextily

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tqdm>=4.36
 pastas>=0.13.0
 contextily
 pyproj
+adjustText

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,7 @@ setup(
         'Programming Language :: Python :: 3.8'
     ],
     platforms='Windows, MacOS, *nix',
-    install_requires=["numpy>=1.15",
-                      "pandas>=1.0",  # note 1.1.5 necessary for Arctic for now
-                      "tqdm>=4.36",
+    install_requires=["tqdm>=4.36",
                       "pastas>=0.13"],
     packages=find_packages(exclude=[]),
     include_package_data=True,

--- a/tests/test_004_maps_plots.py
+++ b/tests/test_004_maps_plots.py
@@ -47,6 +47,11 @@ def test_map_stresses(pstore):
     return
 
 
+def test_map_adjustText(pstore):
+    ax = pstore.maps.stresses(kind="prec", adjust=True)
+    plt.close(ax.figure)
+    return
+
 def test_map_stresslinks(pstore):
     ml = pstore.create_model("oseries1", modelname="ml1")
     pstore.add_model(ml)

--- a/tests/test_004_maps_plots.py
+++ b/tests/test_004_maps_plots.py
@@ -42,15 +42,10 @@ def test_map_oseries_w_bgmap(pstore):
 
 
 def test_map_stresses(pstore):
-    ax = pstore.maps.stresses(kind="prec")
-    plt.close(ax.figure)
-    return
-
-
-def test_map_adjustText(pstore):
     ax = pstore.maps.stresses(kind="prec", adjust=True)
     plt.close(ax.figure)
     return
+
 
 def test_map_stresslinks(pstore):
     ml = pstore.create_model("oseries1", modelname="ml1")


### PR DESCRIPTION
This pull request adds an option for smart label placement using the [adjustText package](https://github.com/Phlya/adjustText). Currently labels are only placed using an offset but that can cause labels to overlap:
![Overzichtskaart_Meetnet_Aamsveen_old_labels](https://user-images.githubusercontent.com/66305055/165336276-68efbcf1-3944-40fa-80b9-69b5d4c76c6e.png)
The `adjust_text` function from adjustText uses an iterative adjustment for label positions to minimize overlaps.
![Overzichtskaart_Meetnet_Aamsveen_new_labels](https://user-images.githubusercontent.com/66305055/165336280-2798c068-4828-4a5e-a869-d6241fd4b499.png)
In this example the `adjust_text` function is relatively slow (<1min) but in problems with fewer points and shorter label strings it is much faster

This does create an extra dependency but the adjustText package is really small and we already support all it's dependencies.



