### PR TITLE
Storing list of model names per oseries

### DIFF
--- a/examples/notebooks/ex02_introduction_to_pastastore_databases.ipynb
+++ b/examples/notebooks/ex02_introduction_to_pastastore_databases.ipynb
@@ -116,13 +116,10 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO:arctic.arctic:Connecting to mongo: mongodb://localhost:27017/ (mongodb://localhost:27017/)\n",
-      "INFO:arctic.store.version_store:Trying to enable sharding...\n",
-      "WARNING:arctic.store.version_store:Library created, but couldn't enable sharding: no such command: 'enablesharding', full error: {'ok': 0.0, 'errmsg': \"no such command: 'enablesharding'\", 'code': 59, 'codeName': 'CommandNotFound'}. This is OK if you're not 'admin'\n",
-      "INFO:arctic.store.version_store:Trying to enable sharding...\n",
-      "WARNING:arctic.store.version_store:Library created, but couldn't enable sharding: no such command: 'enablesharding', full error: {'ok': 0.0, 'errmsg': \"no such command: 'enablesharding'\", 'code': 59, 'codeName': 'CommandNotFound'}. This is OK if you're not 'admin'\n",
-      "INFO:arctic.store.version_store:Trying to enable sharding...\n",
-      "WARNING:arctic.store.version_store:Library created, but couldn't enable sharding: no such command: 'enablesharding', full error: {'ok': 0.0, 'errmsg': \"no such command: 'enablesharding'\", 'code': 59, 'codeName': 'CommandNotFound'}. This is OK if you're not 'admin'\n"
+      "Library created, but couldn't enable sharding: no such command: 'enablesharding', full error: {'ok': 0.0, 'errmsg': \"no such command: 'enablesharding'\", 'code': 59, 'codeName': 'CommandNotFound'}. This is OK if you're not 'admin'\n",
+      "Library created, but couldn't enable sharding: no such command: 'enablesharding', full error: {'ok': 0.0, 'errmsg': \"no such command: 'enablesharding'\", 'code': 59, 'codeName': 'CommandNotFound'}. This is OK if you're not 'admin'\n",
+      "Library created, but couldn't enable sharding: no such command: 'enablesharding', full error: {'ok': 0.0, 'errmsg': \"no such command: 'enablesharding'\", 'code': 59, 'codeName': 'CommandNotFound'}. This is OK if you're not 'admin'\n",
+      "Library created, but couldn't enable sharding: no such command: 'enablesharding', full error: {'ok': 0.0, 'errmsg': \"no such command: 'enablesharding'\", 'code': 59, 'codeName': 'CommandNotFound'}. This is OK if you're not 'admin'\n"
      ]
     }
    ],
@@ -263,7 +260,8 @@
      "text": [
       "PasConnector: library oseries created in /home/david/Github/pastastore/examples/notebooks/pas/oseries\n",
       "PasConnector: library stresses created in /home/david/Github/pastastore/examples/notebooks/pas/stresses\n",
-      "PasConnector: library models created in /home/david/Github/pastastore/examples/notebooks/pas/models\n"
+      "PasConnector: library models created in /home/david/Github/pastastore/examples/notebooks/pas/models\n",
+      "PasConnector: library oseries_models created in /home/david/Github/pastastore/examples/notebooks/pas/oseries_models\n"
      ]
     }
    ],
@@ -320,9 +318,9 @@
     {
      "data": {
       "text/plain": [
-       "<VersionStore at 0x7fb62cdb8790>\n",
-       "    <ArcticLibrary at 0x7fb62cdb8220, arctic_my_connector.oseries>\n",
-       "        <Arctic at 0x7fb6e42d5400, connected to MongoClient(host=['localhost:27017'], document_class=dict, tz_aware=False, connect=True, maxpoolsize=4, sockettimeoutms=600000, connecttimeoutms=2000, serverselectiontimeoutms=30000)>"
+       "<VersionStore at 0x7feba3f22df0>\n",
+       "    <ArcticLibrary at 0x7fec3619adc0, arctic_my_connector.oseries>\n",
+       "        <Arctic at 0x7fec36efd400, connected to MongoClient(host=['localhost:27017'], document_class=dict, tz_aware=False, connect=True, maxpoolsize=4, sockettimeoutms=600000, connecttimeoutms=2000, serverselectiontimeoutms=30000)>"
       ]
      },
      "execution_count": 11,
@@ -1128,6 +1126,15 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: Cannot determine frequency of series oseries1: freq=None. The time series is irregular.\n",
+      "INFO: Inferred frequency for time series prec1: freq=D\n",
+      "INFO: Inferred frequency for time series evap1: freq=D\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
        "Model(oseries=oseries1, name=oseries1, constant=True, noisemodel=True)"
@@ -1165,6 +1172,46 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['oseries1']"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "store.models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'oseries1': ['oseries1']}"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "store.oseries_models"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1177,16 +1224,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO: Cannot determine frequency of series oseries1: freq=None. The time series is irregular.\n",
+      "INFO: User provided frequency for time series prec1: freq=D\n",
+      "INFO: User provided frequency for time series evap1: freq=D\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "Model(oseries=oseries1, name=oseries1, constant=True, noisemodel=True)"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1207,7 +1263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1216,7 +1272,7 @@
        "['oseries1']"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1236,7 +1292,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1252,7 +1308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1262,7 +1318,7 @@
        " - <PasConnector> 'my_third_connector': 1 oseries, 2 stresses, 0 models"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1273,7 +1329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1282,13 +1338,33 @@
        "[]"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "store.models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{}"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "store.oseries_models"
    ]
   },
   {
@@ -1309,7 +1385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1340,7 +1416,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1350,7 +1426,7 @@
        " - <PasConnector> 'my_third_connector': 2 oseries, 4 stresses, 0 models"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1375,7 +1451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1385,14 +1461,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Bulk creation models: 100%|███████████████████████| 2/2 [00:00<00:00,  6.81it/s]\n"
+      "Bulk creation models: 100%|██████████| 2/2 [00:00<00:00,  6.47it/s]\n"
      ]
     }
    ],
@@ -1413,7 +1489,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -1423,7 +1499,7 @@
        " - <PasConnector> 'my_third_connector': 2 oseries, 4 stresses, 2 models"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1434,14 +1510,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Solving models: 100%|█████████████████████████████| 2/2 [00:01<00:00,  1.00it/s]\n"
+      "Solving models: 100%|██████████| 2/2 [00:02<00:00,  1.07s/it]\n"
      ]
     }
    ],
@@ -1458,7 +1534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -1523,7 +1599,7 @@
        "oseries1    50.095186  "
       ]
      },
-     "execution_count": 42,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1535,7 +1611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -1584,7 +1660,7 @@
        "oseries1  92.904658  0.114492"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1607,52 +1683,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:arctic.arctic:Connecting to mongo: mongodb://localhost:27017/ (mongodb://localhost:27017/)\n",
-      "INFO:arctic.arctic:Dropping collection: models\n",
-      "INFO:arctic.arctic:Dropping collection: models.versions\n",
-      "INFO:arctic.arctic:Dropping collection: models.version_nums\n",
-      "INFO:arctic.arctic:Dropping collection: models.ARCTIC\n",
-      "INFO:arctic.arctic:Dropping collection: models.snapshots\n",
-      "INFO:arctic.arctic:Dropping collection: stresses\n",
-      "INFO:arctic.arctic:Dropping collection: stresses.snapshots\n",
-      "INFO:arctic.arctic:Dropping collection: stresses.version_nums\n",
-      "INFO:arctic.arctic:Dropping collection: stresses.ARCTIC\n",
-      "INFO:arctic.arctic:Dropping collection: stresses.versions\n",
-      "INFO:arctic.arctic:Dropping collection: oseries\n",
-      "INFO:arctic.arctic:Dropping collection: oseries.versions\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deleting ArcticConnector database: 'my_connector' ...\n",
-      " - deleted: my_connector.models\n",
-      " - deleted: my_connector.stresses\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:arctic.arctic:Dropping collection: oseries.version_nums\n",
-      "INFO:arctic.arctic:Dropping collection: oseries.snapshots\n",
-      "INFO:arctic.arctic:Dropping collection: oseries.ARCTIC\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " - deleted: my_connector.oseries\n",
-      "... Done!\n"
+      "Deleting ArcticConnector database: 'my_connector' ... Done!\n"
      ]
     }
    ],
@@ -1662,7 +1700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -1679,14 +1717,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deleting PasConnector database: 'my_third_connector' ... Done!\n"
+      "Deleting PasConnector database: 'my_third_connector' ...  Done!\n"
      ]
     }
    ],

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -866,9 +866,9 @@ class BaseConnector(ABC):
         Parameters
         ----------
         onam : str
-            name of oserise
+            name of oseries
         mlnames : Union[str, List[str]]
-            name or list of names of models for a oseries with name
+            model name or list of model names for an oseries with name
             onam.
         """
         # get stored list of model names

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -26,7 +26,8 @@ class BaseConnector(ABC):
     override each abstractmethod and abstractproperty.
     """
 
-    _default_library_names = ["oseries", "stresses", "models"]
+    _default_library_names = ["oseries", "stresses", "models",
+                              "oseries_models"]
 
     # whether to check model timeseries contents against stored copies
     check_model_series_values = True
@@ -406,7 +407,7 @@ class BaseConnector(ABC):
             raise ItemInLibraryException(f"Model with name '{name}' "
                                          "already in 'models' library!")
         self._clear_cache("_modelnames_cache")
-        self.oseries_models._add_model(mldict["oseries"]["name"], name)
+        self._add_oseries_model_links(str(mldict["oseries"]["name"]), name)
 
     @staticmethod
     def _parse_series_input(series: Union[FrameorSeriesUnion, ps.TimeSeries],
@@ -525,7 +526,7 @@ class BaseConnector(ABC):
             mldict = self.get_models(n, return_dict=True)
             oname = mldict["oseries"]["name"]
             self._del_item("models", n)
-            self.oseries_models._del_model(oname, n)
+            self._del_oseries_model_link(oname, n)
         self._clear_cache("_modelnames_cache")
 
     def del_oseries(self, names: Union[list, str]):
@@ -858,6 +859,93 @@ class BaseConnector(ABC):
             yield self.get_models(mlnam, return_dict=return_dict,
                                   progressbar=False)
 
+    def _add_oseries_model_links(self, onam: str,
+                                 mlnames: Union[str, List[str]]):
+        """Add model name to stored list of models per oseries.
+
+        Parameters
+        ----------
+        onam : str
+            name of oserise
+        mlnames : Union[str, List[str]]
+            name or list of names of models for a oseries with name
+            onam.
+        """
+        # get stored list of model names
+        if str(onam) in self.oseries_with_models:
+            modellist = self._get_item("oseries_models", onam)
+        else:
+            # else empty list
+            modellist = []
+        # if one model name, make list for loop
+        if isinstance(mlnames, str):
+            mlnames = [mlnames]
+        # loop over model names
+        for iml in mlnames:
+            # if not present, add to list
+            if iml not in modellist:
+                modellist.append(iml)
+        self._add_item("oseries_models", modellist, onam, overwrite=True)
+        self._clear_cache("oseries_models")
+
+    def _del_oseries_model_link(self, onam, mlnam):
+        """Delete model name from stored list of models per oseries.
+
+        Parameters
+        ----------
+        onam : str
+            name of oseries
+        mlnam : str
+            name of model
+        """
+        modellist = self._get_item("oseries_models", onam)
+        modellist.remove(mlnam)
+        if len(modellist) == 0:
+            self._del_item("oseries_models", onam)
+        else:
+            self._add_item("oseries_models", modellist, onam, overwrite=True)
+        self._clear_cache("oseries_models")
+
+    def _update_all_oseries_model_links(self):
+        """Add all model names to oseries metadata dictionaries.
+
+        Used for old PastaStore versions, where relationship between
+        oseries and models was not stored. If there are any models in
+        the database and if the oseries_models library is empty, loops
+        through all models to determine which oseries each model belongs
+        to.
+        """
+        # get oseries_models library if there are any contents, if empty
+        # add all model links.
+        if self.n_models > 0:
+            if len(self.oseries_models) == 0:
+                links = self._get_all_oseries_model_links()
+                for onam, mllinks in tqdm(links.items(),
+                                          desc="Store models per oseries",
+                                          total=len(links)):
+                    self._add_oseries_model_links(onam, mllinks)
+
+    def _get_all_oseries_model_links(self):
+        """Get all model names per oseries in dictionary.
+
+        Returns
+        -------
+        links : dict
+            dictionary with oseries names as keys and lists of model names as
+            values
+        """
+        links = {}
+        for mldict in tqdm(self.iter_models(return_dict=True),
+                           total=self.n_models,
+                           desc="Get models per oseries"):
+            onam = mldict["oseries"]["name"]
+            mlnam = mldict["name"]
+            if onam in links:
+                links[onam].append(mlnam)
+            else:
+                links[onam] = [mlnam]
+        return links
+
     @staticmethod
     def _clear_cache(libname: str) -> None:
         """Clear cached property."""
@@ -894,6 +982,22 @@ class BaseConnector(ABC):
     @property
     def n_models(self):
         return len(self.model_names)
+
+    @property  # type: ignore
+    @functools.lru_cache()
+    def oseries_models(self):
+        """List of model names per oseries.
+
+        Returns
+        -------
+        d : dict
+            dictionary with oseries names as keys and list of model names as
+            values
+        """
+        d = {}
+        for onam in self.oseries_with_models:
+            d[onam] = self._get_item("oseries_models", onam)
+        return d
 
 
 class ConnectorUtil:
@@ -1413,105 +1517,3 @@ class ModelAccessor:
             model
         """
         yield from self.conn.iter_models()
-
-
-class OseriesModelsAccessor:
-    """Object for getting list of model names per oseries.
-
-    Provides dict-like access for obtaining models for a certain
-    location/oseries (i.e. PastaStore.oseries_models["oseries1"]). On
-    initialization of a Connector this dictionary is built by running
-    through all models and storing a list of model names per oseries
-    name.
-    """
-
-    def __init__(self, conn):
-        """Initialize oseries models accessor.
-
-        Parameters
-        ----------
-        conn : pastastore.*Connector
-            pastastore Connector object
-        """
-        self.conn = conn
-        self.oseries_models_dict = {}
-        self._build_dict()
-
-    def __repr__(self):
-        """String represenation.
-
-        Returns
-        -------
-        str
-            string representation of oseries_models dictionary.
-        """
-        return self.oseries_models_dict.__repr__()
-
-    def __getitem__(self, name: str):
-        """Get list of model names with oseries name as key.
-
-        Parameters
-        ----------
-        name : str
-            name of oseries
-
-        Returns
-        -------
-        list
-            list of model names (str)
-        """
-        return self.oseries_models_dict[name]
-
-    def __setitem__(self, oseries_name: str, model_name: str):
-        """Add model name to oseries_models dictionary.
-
-        Parameters
-        ----------
-        oseries_name : str
-            name of oseries
-        model_name : str
-            name of model
-        """
-        self._add_model(oseries_name, model_name)
-
-    def _build_dict(self):
-        """Build dictionary with list of model names per oseries."""
-        if self.conn.n_models > 0:
-            for mlnam in tqdm(self.conn._modelnames_cache,
-                              desc="Build oseries_model dictionary"):
-                ml = self.conn.get_models(mlnam, return_dict=True)
-                onam = ml["oseries"]["name"]
-                if onam in self.oseries_models_dict:
-                    self.oseries_models_dict[onam].append(mlnam)
-                else:
-                    self.oseries_models_dict[onam] = [mlnam]
-
-    def _add_model(self, oseries_name: str, model_name: str):
-        """Add model name to list for oseries.
-
-        Parameters
-        ----------
-        oseries_name : str
-            name of oseries
-        model_name : str
-            name of models
-        """
-        if oseries_name in self.oseries_models_dict:
-            if model_name not in self.oseries_models_dict[oseries_name]:
-                self.oseries_models_dict[oseries_name].append(model_name)
-        else:
-            self.oseries_models_dict[oseries_name] = [model_name]
-
-    def _del_model(self, oseries_name: str, model_name: str):
-        """Delete model name from list for oseries.
-
-        Parameters
-        ----------
-        oseries_name : str
-            name of oseries
-        model_name : str
-            name of model
-        """
-        self.oseries_models_dict[oseries_name].remove(model_name)
-        if len(self.oseries_models_dict[oseries_name]) == 0:
-            del self.oseries_models_dict[oseries_name]

--- a/pastastore/store.py
+++ b/pastastore/store.py
@@ -105,6 +105,10 @@ class PastaStore:
     def oseries_models(self):
         return self.conn.oseries_models
 
+    @property
+    def oseries_with_models(self):
+        return self.conn.oseries_with_models
+
     def __repr__(self):
         """Representation string of the object."""
         return f"<PastaStore> {self.name}: \n - " + self.conn.__str__()

--- a/pastastore/util.py
+++ b/pastastore/util.py
@@ -83,7 +83,7 @@ def delete_arctic_connector(conn=None,
 
     arc = arctic.Arctic(connstr)
 
-    print(f"Deleting ArcticConnector database: '{name}' ...")
+    print(f"Deleting ArcticConnector database: '{name}' ... ", end="")
     # get library names
     if libraries is None:
         libs = []
@@ -97,12 +97,14 @@ def delete_arctic_connector(conn=None,
 
     for lib in libs:
         arc.delete_library(lib)
-        print(f" - deleted: {lib}")
-    print("... Done!")
+        if libraries is not None:
+            print()
+            print(f" - deleted: {lib}")
+    print("Done!")
 
 
 def delete_dict_connector(conn, libraries: Optional[List[str]] = None) -> None:
-    print(f"Deleting DictConnector: '{conn.name}' ...", end="")
+    print(f"Deleting DictConnector: '{conn.name}' ... ", end="")
     if libraries is None:
         del conn
         print(" Done!")
@@ -111,12 +113,12 @@ def delete_dict_connector(conn, libraries: Optional[List[str]] = None) -> None:
             print()
             delattr(conn, f"lib_{conn.libname[lib]}")
             print(f" - deleted: {lib}")
-    print("... Done!")
+    print("Done!")
 
 
 def delete_pas_connector(conn, libraries: Optional[List[str]] = None) -> None:
     import shutil
-    print(f"Deleting PasConnector database: '{conn.name}' ...", end="")
+    print(f"Deleting PasConnector database: '{conn.name}' ... ", end="")
     if libraries is None:
         shutil.rmtree(conn.path)
         print(" Done!")
@@ -125,7 +127,7 @@ def delete_pas_connector(conn, libraries: Optional[List[str]] = None) -> None:
             print()
             shutil.rmtree(os.path.join(conn.path, lib))
             print(f" - deleted: {lib}")
-        print("... Done!")
+        print("Done!")
 
 
 def delete_pastastore(pstore, libraries: Optional[List[str]] = None) -> None:

--- a/tests/test_002_connectors.py
+++ b/tests/test_002_connectors.py
@@ -61,7 +61,8 @@ def test_add_get_dataframe(request, conn):
     o2 = conn.get_oseries("test_df")
     try:
         assert isinstance(o2, pd.DataFrame)
-        assert (o1 == o2).all().all()
+        # little hack as PasConnector has dtype int after load...
+        assert o1.equals(o2.astype(float))
     finally:
         conn.del_oseries("test_df")
     return


### PR DESCRIPTION
See discussion in #50. 

This is a more efficient implementation than the one presented in #58 . It requires fewer read/writes to store data and is cleaner.
For older existing databases, a new library is created `oseries_models` and if any models are stored, a list of modelnames per oseries will be stored. This only has to be performed once for these older existing databases.