### PR TITLE
Release v1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
           pytest
 
       - name: Run codacy-coverage-reporter
+        if: ${{ github.repository == 'pastas/pastastore' && success() }}
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10"]
         pastas-version:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,19 +13,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install wheel twine build
+    
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        python3 -m build
+        python3 -m twine upload --repository pypi dist/*

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -1271,7 +1271,7 @@ class ConnectorUtil:
         if "series" not in mdict["oseries"]:
             name = str(mdict["oseries"]["name"])
             if name not in self.oseries.index:
-                msg = "oseries {} not present in project".format(name)
+                msg = "oseries '{}' not present in library".format(name)
                 raise LookupError(msg)
             mdict["oseries"]["series"] = self.get_oseries(name)
             # update tmin/tmax from time series
@@ -1330,7 +1330,7 @@ class ConnectorUtil:
                                 stress["settings"]["tmin"] = stress["series"].index[0]
                                 stress["settings"]["tmax"] = stress["series"].index[-1]
                         else:
-                            msg = "stress '{}' not present in project".format(name)
+                            msg = "stress '{}' not present in library".format(name)
                             raise KeyError(msg)
         # hack for pcov w dtype object (when filled with NaNs on store?)
         if "fit" in mdict:

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -1244,10 +1244,7 @@ class ConnectorUtil:
             meta = pd.DataFrame(metalist)
         elif len(metalist) == 0:
             meta = pd.DataFrame()
-        if "name" in meta.columns:
-            meta.set_index("name", inplace=True)
-        else:
-            meta.index = names
+        meta.index = names
         return meta
 
     def _parse_model_dict(self, mdict: dict, update_ts_settings: bool = False):

--- a/pastastore/connectors.py
+++ b/pastastore/connectors.py
@@ -421,12 +421,12 @@ class PystoreConnector(BaseConnector, ConnectorUtil):
 class DictConnector(BaseConnector, ConnectorUtil):
     conn_type = "dict"
 
-    def __init__(self, name: str):
+    def __init__(self, name: str = "pastas_db"):
         """Create DictConnector object that stores data in dictionaries.
 
         Parameters
         ----------
-        name : str
+        name : str, optional
             user-specified name of the connector
         """
         self.name = name

--- a/pastastore/connectors.py
+++ b/pastastore/connectors.py
@@ -571,17 +571,18 @@ class PasConnector(BaseConnector, ConnectorUtil):
         Parameters
         ----------
         name : str
-            user-specified name of the connector
+            user-specified name of the connector, this will be the name of the
+            directory in which the data will be stored
         path : str
-            path to directory for reading/writing data
+            path to directory for storing the data
         """
         self.name = name
-        self.path = os.path.abspath(path)
-        self.relpath = os.path.relpath(path)
+        self.path = os.path.abspath(os.path.join(path, self.name))
+        self.relpath = os.path.relpath(self.path)
         self._initialize()
         self.models = ModelAccessor(self)
         # for older versions of PastaStore, if oseries_models library is empty
-        # populate oseries - models database
+        # populate oseries_models library
         self._update_all_oseries_model_links()
 
     def _initialize(self) -> None:
@@ -589,7 +590,7 @@ class PasConnector(BaseConnector, ConnectorUtil):
         for val in self._default_library_names:
             libdir = os.path.join(self.path, val)
             if not os.path.exists(libdir):
-                print(f"PasConnector: library {val} created in {libdir}")
+                print(f"PasConnector: library '{val}' created in '{libdir}'")
                 os.makedirs(libdir)
             else:
                 print(

--- a/pastastore/connectors.py
+++ b/pastastore/connectors.py
@@ -15,7 +15,7 @@ FrameorSeriesUnion = Union[pd.DataFrame, pd.Series]
 warnings.showwarning = _custom_warning
 
 
-class ArcticConnector(BaseConnector, ConnectorUtil):
+class ArcticConnector(BaseConnector, ConnectorUtil):  # pragma: no cover
     conn_type = "arctic"
 
     def __init__(self, name: str, connstr: str):
@@ -24,10 +24,10 @@ class ArcticConnector(BaseConnector, ConnectorUtil):
 
         Parameters
         ----------
+        name : str
+            name of the database
         connstr : str
             connection string (e.g. 'mongodb://localhost:27017/')
-        name : str
-            name of the project
         """
         try:
             import arctic
@@ -198,7 +198,7 @@ class ArcticConnector(BaseConnector, ConnectorUtil):
         return self._get_library("oseries_models").list_symbols()
 
 
-class PystoreConnector(BaseConnector, ConnectorUtil):
+class PystoreConnector(BaseConnector, ConnectorUtil):  # pragma: no cover
     conn_type = "pystore"
 
     def __init__(self, name: str, path: str):

--- a/pastastore/datasets.py
+++ b/pastastore/datasets.py
@@ -40,7 +40,7 @@ def example_pastastore(conn="DictConnector"):
         conn = _default_connector(conn)
 
     # initialize PastaStore
-    pstore = pst.PastaStore("example", conn)
+    pstore = pst.PastaStore(conn, "example")
 
     # add data
 
@@ -111,63 +111,60 @@ def example_pastastore(conn="DictConnector"):
     )
     # TODO: temporary fix for older version of hydropandas that does not
     # read Menyanthes time series names correctly.
-    try:
-        # multiwell notebook data
-        fname = os.path.join(datadir, "MenyanthesTest.men")
-        # meny = ps.read.MenyData(fname)
-        meny = hpd.ObsCollection.from_menyanthes(fname, hpd.Obs)
+    # multiwell notebook data
+    fname = os.path.join(datadir, "MenyanthesTest.men")
+    # meny = ps.read.MenyData(fname)
+    meny = hpd.ObsCollection.from_menyanthes(fname, hpd.Obs)
 
-        oseries = meny.loc["Obsevation well", "obs"]
-        ometa = {
-            "x": oseries.meta["x"],
-            "y": oseries.meta["y"],
-        }
-        pstore.add_oseries(oseries.dropna(), "head_mw", metadata=ometa)
+    oseries = meny.loc["Obsevation well", "obs"]
+    ometa = {
+        "x": oseries.meta["x"],
+        "y": oseries.meta["y"],
+    }
+    pstore.add_oseries(oseries.dropna(), "head_mw", metadata=ometa)
 
-        prec = meny.loc["Precipitation", "obs"]
-        prec.index = prec.index.round("D")
-        prec.name = "prec"
-        pmeta = {
-            "x": prec.meta["x"],
-            "y": prec.meta["y"],
-        }
-        pstore.add_stress(prec, "prec_mw", kind="prec", metadata=pmeta)
-        evap = meny.loc["Evaporation", "obs"]
-        evap.index = evap.index.round("D")
-        evap.name = "evap"
-        emeta = {
-            "x": evap.meta["x"],
-            "y": evap.meta["y"],
-        }
-        pstore.add_stress(evap, "evap_mw", kind="evap", metadata=emeta)
+    prec = meny.loc["Precipitation", "obs"]
+    prec.index = prec.index.round("D")
+    prec.name = "prec"
+    pmeta = {
+        "x": prec.meta["x"],
+        "y": prec.meta["y"],
+    }
+    pstore.add_stress(prec, "prec_mw", kind="prec", metadata=pmeta)
+    evap = meny.loc["Evaporation", "obs"]
+    evap.index = evap.index.round("D")
+    evap.name = "evap"
+    emeta = {
+        "x": evap.meta["x"],
+        "y": evap.meta["y"],
+    }
+    pstore.add_stress(evap, "evap_mw", kind="evap", metadata=emeta)
 
-        pressure = meny.loc["Air Pressure", "obs"]
-        pressure.index = pressure.index.round("D")
-        pressure.name = "pressure"
-        pres_meta = {
-            "x": pressure.meta["x"],
-            "y": pressure.meta["y"],
-        }
-        pstore.add_stress(pressure, "pressure_mw", kind="pressure", metadata=pres_meta)
+    pressure = meny.loc["Air Pressure", "obs"]
+    pressure.index = pressure.index.round("D")
+    pressure.name = "pressure"
+    pres_meta = {
+        "x": pressure.meta["x"],
+        "y": pressure.meta["y"],
+    }
+    pstore.add_stress(pressure, "pressure_mw", kind="pressure", metadata=pres_meta)
 
-        extraction_names = [
-            "Extraction 1",
-            "Extraction 2",
-            "Extraction 3",
-            "Extraction 4",
-        ]
-        for extr in extraction_names:
-            ts = meny.loc[extr, "obs"]
-            wmeta = {"x": ts.meta["x"], "y": ts.meta["y"]}
-            # replace spaces in names for Pastas
-            name = extr.replace(" ", "_").lower()
-            # resample to daily timestep
-            ts_d = timestep_weighted_resample(
-                ts, pd.date_range(ts.index[0], ts.index[-1], freq="D")
-            )
-            pstore.add_stress(ts_d, name, kind="well", metadata=wmeta)
-    except KeyError:
-        pass
+    extraction_names = [
+        "Extraction 1",
+        "Extraction 2",
+        "Extraction 3",
+        "Extraction 4",
+    ]
+    for extr in extraction_names:
+        ts = meny.loc[extr, "obs"]
+        wmeta = {"x": ts.meta["x"], "y": ts.meta["y"]}
+        # replace spaces in names for Pastas
+        name = extr.replace(" ", "_").lower()
+        # resample to daily timestep
+        ts_d = timestep_weighted_resample(
+            ts, pd.date_range(ts.index[0], ts.index[-1], freq="D")
+        )
+        pstore.add_stress(ts_d, name, kind="well", metadata=wmeta)
 
     return pstore
 

--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -15,6 +15,8 @@ follows::
     pstore.maps.add_background_map(ax)  # for adding a background map
 """
 
+from collections.abc import Iterable
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -99,6 +101,10 @@ class Plots:
                 fig, axes = plt.subplots(1, 1, figsize=figsize)
         else:
             axes = ax
+            if isinstance(axes, Iterable):
+                fig = axes[0].figure
+            else:
+                fig = axes.figure
 
         tsdict = self.pstore.conn._get_series(
             libname, names, progressbar=progressbar, squeeze=False
@@ -572,7 +578,9 @@ class Maps:
             df = self.pstore.stresses
 
         if kind is not None:
-            mask = df["kind"] == kind
+            if isinstance(kind, str):
+                kind = [kind]
+            mask = df["kind"].isin(kind)
             stresses = df[mask]
         else:
             stresses = df
@@ -1165,7 +1173,7 @@ class Maps:
                     markersize=10,
                 )
             ]
-            for kind in skind:
+            for kind in kinds:
                 (c,) = np.where(skind == kind)
                 legend_elements.append(
                     Line2D(

--- a/pastastore/util.py
+++ b/pastastore/util.py
@@ -485,7 +485,7 @@ def frontiers_checks(
     check4_gain: bool = True,
     check5_parambounds: bool = False,
     csv_dir: Optional[str] = None,
-) -> pd.DataFrame:
+) -> pd.DataFrame:  # pragma: no cover
     """Check models in a PastaStore to see if they pass reliability criteria.
 
     The reliability criteria are taken from Brakenhoff et al. 2022 [bra_2022]_.
@@ -738,7 +738,7 @@ def frontiers_aic_select(
     modelnames: Optional[List[str]] = None,
     oseries: Optional[List[str]] = None,
     full_output: bool = False,
-) -> pd.DataFrame:
+) -> pd.DataFrame:  # pragma: no cover
     """Select the best model structure based on the minimum AIC.
 
     As proposed by Brakenhoff et al. 2022 [bra_2022]_.

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ folder called `pastas_db` in the current directory).
 import pastastore as pst
 
 # create connector instance
-conn = pst.PasConnector("my_db", path="./pastas_db")
+conn = pst.PasConnector(name="pastas_db", path=".")
 ```
 
 The next step is to pass that connector to the `PastaStore` object. This object
@@ -50,7 +50,7 @@ build and analyze models.
 
 ```python
 # create PastaStore instance
-pstore = pst.PastaStore("my_project", conn)
+pstore = pst.PastaStore(conn)
 ```
 
 Now the user can add time series, models or analyze or visualize existing
@@ -77,8 +77,18 @@ pstore.maps.add_background_map(ax)  # add a background map
 # plot my_oseries time series
 ax2 = pstore.plot.oseries(names=["my_oseries"])
 
+# create a model with pastas
+import pastas as ps
+ml = ps.Model(oseries, name="my_model")
+
+# add model to database
+pstore.add_model(ml)
+
+# load model from database
+ml2 = pstore.get_models("my_model")
+
 # export whole database to a zip file
-pstore.to_zip("my_db_backup.zip")
+pstore.to_zip("my_backup.zip")
 ```
 
 For more elaborate examples, refer to the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ params = ["dict", "pas"]  # "arctic" and "pystore" removed for CI, can be tested
 
 
 def initialize_project(conn):
-    pstore = pst.PastaStore("test_project", conn)
+    pstore = pst.PastaStore(conn, "test_project")
 
     # oseries 1
     o = pd.read_csv("./tests/data/obs.csv", index_col=0, parse_dates=True)

--- a/tests/test_003_pastastore.py
+++ b/tests/test_003_pastastore.py
@@ -296,3 +296,22 @@ def test_example_pastastore():
 
     _ = example_pastastore()
     return
+
+
+def test_validate_names():
+    from pastastore.util import validate_names
+
+    validate_names(s="(test)") == "test"
+    validate_names(d={"(test)": 2})["test"]
+
+
+def test_meta_with_name(pstore):
+    s = pd.Series(
+        index=pd.date_range("2020-01-01", periods=10, freq="D"),
+        data=np.arange(10),
+        dtype=float,
+    )
+    smeta = {"name": "not_what_i_want"}
+    pstore.add_stress(s, "what_i_want", kind="special", metadata=smeta)
+    assert "what_i_want" in pstore.stresses.index, "This is not right."
+    pstore.del_stress("what_i_want")

--- a/tests/test_004_yaml.py
+++ b/tests/test_004_yaml.py
@@ -127,7 +127,6 @@ def test_write_yaml_minimal(request, pstore):
 
 
 @pytest.mark.dependency()
-@pytest.mark.xfail(reason="wellmodel settings change only in 0.23.1 currently.")
 def test_write_yaml_minimal_nearest(request, pstore):
     depends(
         request,

--- a/tests/test_005_maps_plots.py
+++ b/tests/test_005_maps_plots.py
@@ -9,19 +9,26 @@ from pytest_dependency import depends
 def test_plot_oseries(pstore):
     ax = pstore.plots.oseries()
     plt.close(ax.figure)
-    return
 
 
 def test_plot_stresses(pstore):
-    ax = pstore.plots.oseries()
+    ax = pstore.plots.stresses()
     plt.close(ax.figure)
-    return
 
 
 def test_plot_stresses_availability(pstore):
     ax = pstore.plots.data_availability("stresses", kind="prec", set_yticks=True)
     plt.close(ax.figure)
-    return
+
+
+@pytest.mark.dependency()
+def test_cumulative_hist(request, pstore):
+    ml1 = pstore.create_model("oseries1")
+    pstore.add_model(ml1)
+    ml2 = pstore.create_model("oseries2")
+    pstore.add_model(ml2)
+    ax = pstore.plots.cumulative_hist()
+    plt.close(ax.figure)
 
 
 # %% maps
@@ -29,18 +36,16 @@ def test_plot_stresses_availability(pstore):
 
 def test_map_oseries_w_bgmap(pstore):
     ax = pstore.maps.oseries()
-    # only test bgmap once for arctic
-    if pstore.type == "arctic":
+    # only test bgmap once for pas
+    if pstore.type == "pas":
         pstore.maps.add_background_map(ax)
     plt.close(ax.figure)
-    return
 
 
 @requires_pkg("adjustText")
 def test_map_stresses(pstore):
     ax = pstore.maps.stresses(kind="prec", adjust=True)
     plt.close(ax.figure)
-    return
 
 
 def test_map_stresslinks(pstore):
@@ -48,16 +53,12 @@ def test_map_stresslinks(pstore):
     pstore.add_model(ml)
     ax = pstore.maps.stresslinks()
     plt.close(ax.figure)
-    return
 
 
 @pytest.mark.dependency()
 def test_map_models(request, pstore):
-    ml = pstore.create_model("oseries1")
-    pstore.add_model(ml)
     ax = pstore.maps.models()
     plt.close(ax.figure)
-    return
 
 
 @pytest.mark.dependency()
@@ -65,4 +66,14 @@ def test_map_model(request, pstore):
     depends(request, [f"test_map_models[{pstore.type}]"])
     ax = pstore.maps.model("oseries1")
     plt.close(ax.figure)
-    return
+
+
+@pytest.mark.dependency()
+def test_map_modelstat(request, pstore):
+    ax = pstore.maps.modelstat("evp")
+    plt.close(ax.figure)
+
+
+@pytest.mark.dependency()
+def test_list_ctx_providers(request, pstore):
+    pstore.maps._list_contextily_providers()

--- a/tests/test_006_benchmark.py
+++ b/tests/test_006_benchmark.py
@@ -92,7 +92,7 @@ def test_benchmark_read_series_arctic(benchmark):
 
 
 def build_model(conn):
-    store = pst.PastaStore("test", conn)
+    store = pst.PastaStore(conn, "test")
 
     # oseries nb1
     if "oseries_nb1" not in store.oseries.index:


### PR DESCRIPTION
Deals with #85 and #87. 

Warning, this new version does introduce two breaking changes:
- This does introduce a breaking change, where people with old code will have to switch the order of the arguments from `pst.PastaStore(name, connector)` to `pst.PastaStore(connector, name=name)` with the name becoming optional.
- Also in `pst.PasConnector` the `name` argument is now used to specify the directory name in which the database will be stored. The `path` argument defines the location of that directory. This is also a breaking change and will require users to modify their `PasConnector` from `pst.PasConnector("unused_name", path="./pastas_db")` to `pst.PasConnector("pastas_db", path=".")`. This is more in line with the other Connectors.

Some minor improvements to testing, coverage and documentation are also included.

