### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         pastas-version:
           [
             "git+https://github.com/pastas/pastas.git@v0.22.0",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
@@ -47,8 +48,7 @@ documentation = "https://pastastore.readthedocs.io/en/latest/"
 lint = ["black", "flake8", "isort"]
 optional = ["contextily", "pyproj", "adjustText"]
 test = [
-    "pastastore[lint,optional]",
-    "arcticdb",
+    "pastastore[lint,optional,arcticdb]",
     "hydropandas",
     "coverage",
     "codecov",
@@ -62,9 +62,7 @@ pystore = ["fsspec>=0.3.3", "python-snappy", "dask[dataframe]"]
 arctic = [
     "arctic", # will not work as releases not uploaded to PyPI
 ]
-arcticdb = [
-    "arcticdb",
-]
+arcticdb = ["arcticdb"]
 docs = [
     "pastastore[optional]",
     "sphinx_rtd_theme",


### PR DESCRIPTION
Now that Pastas supports it (https://github.com/pastas/pastas/pull/588), Pastastore should be fine as well