### PR TITLE
Deprecate PystoreConnector and ArcticConnector

### DIFF
--- a/pastastore/connectors.py
+++ b/pastastore/connectors.py
@@ -29,6 +29,12 @@ class ArcticConnector(BaseConnector, ConnectorUtil):  # pragma: no cover
         connstr : str
             connection string (e.g. 'mongodb://localhost:27017/')
         """
+        warnings.warn(
+            "ArcticConnector is deprecated. Please use a different "
+            "connector, e.g. `pst.ArcticDBConnector`.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
         try:
             import arctic
         except ModuleNotFoundError as e:
@@ -392,6 +398,12 @@ class PystoreConnector(BaseConnector, ConnectorUtil):  # pragma: no cover
         path : str
             path to the pystore directory
         """
+        warnings.warn(
+            "PystoreConnector is deprecated. Please use a different "
+            "connector, e.g. `pst.PasConnector`.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
         try:
             import pystore
         except ModuleNotFoundError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,16 +58,9 @@ test = [
     "pytest-dependency",
     "pytest-benchmark",
     "codacy-coverage",
-    "lxml",                               # temporary fix: for hydropandas 0.8.0
+    "lxml",
 ]
-pystore = ["fsspec>=0.3.3", "python-snappy", "dask[dataframe]"]
-arctic = [
-    "arctic", # will not work as releases not uploaded to PyPI
-]
-arcticdb = [
-    "arcticdb",
-    "protobuf~=4.0",
-] # TODO: temporarily set protobuf to version 4
+arcticdb = ["arcticdb"]
 docs = [
     "pastastore[optional]",
     "sphinx_rtd_theme",

--- a/tests/test_006_benchmark.py
+++ b/tests/test_006_benchmark.py
@@ -30,22 +30,6 @@ def test_benchmark_write_series_pas(benchmark):
 
 
 @pytest.mark.benchmark(group="write_series")
-@requires_pkg("pystore")
-def test_benchmark_write_series_pystore(benchmark):
-    path = "./tests/data/pystore"
-    conn = pst.PystoreConnector("test", path)
-    _ = benchmark(series_write, conn=conn)
-
-
-@pytest.mark.benchmark(group="write_series")
-@requires_pkg("arctic")
-def test_benchmark_write_series_arctic(benchmark):
-    connstr = "mongodb://localhost:27017/"
-    conn = pst.ArcticConnector("test", connstr)
-    _ = benchmark(series_write, conn=conn)
-
-
-@pytest.mark.benchmark(group="write_series")
 @requires_pkg("arcticdb")
 def test_benchmark_write_series_arcticdb(benchmark):
     uri = "lmdb://./arctic_db/"
@@ -70,22 +54,6 @@ def series_read(conn):
 @pytest.mark.benchmark(group="read_series")
 def test_benchmark_read_series_pas(benchmark):
     conn = pst.PasConnector("test", "./tests/data/pas")
-    _ = benchmark(series_read, conn=conn)
-
-
-@pytest.mark.benchmark(group="read_series")
-@requires_pkg("pystore")
-def test_benchmark_read_series_pystore(benchmark):
-    path = "./tests/data/pystore"
-    conn = pst.PystoreConnector("test", path)
-    _ = benchmark(series_read, conn=conn)
-
-
-@pytest.mark.benchmark(group="read_series")
-@requires_pkg("arctic")
-def test_benchmark_read_series_arctic(benchmark):
-    connstr = "mongodb://localhost:27017/"
-    conn = pst.ArcticConnector("test", connstr)
     _ = benchmark(series_read, conn=conn)
 
 
@@ -146,24 +114,6 @@ def test_benchmark_write_model_pas(benchmark):
 
 
 @pytest.mark.benchmark(group="write_model")
-@requires_pkg("pystore")
-def test_benchmark_write_model_pystore(benchmark):
-    path = "./tests/data/pystore"
-    conn = pst.PystoreConnector("test", path)
-    ml = build_model(conn)
-    _ = benchmark(write_model, conn=conn, ml=ml)
-
-
-@pytest.mark.benchmark(group="write_model")
-@requires_pkg("arctic")
-def test_benchmark_write_model_arctic(benchmark):
-    connstr = "mongodb://localhost:27017/"
-    conn = pst.ArcticConnector("test", connstr)
-    ml = build_model(conn)
-    _ = benchmark(write_model, conn=conn, ml=ml)
-
-
-@pytest.mark.benchmark(group="write_model")
 @requires_pkg("arcticdb")
 def test_benchmark_write_model_arcticdb(benchmark):
     uri = "lmdb://./arctic_db/"
@@ -183,24 +133,6 @@ def write_model_nocheckts(conn, ml):
 @pytest.mark.benchmark(group="write_model")
 def test_benchmark_write_model_nocheckts_pas(benchmark):
     conn = pst.PasConnector("test", "./tests/data/pas")
-    ml = build_model(conn)
-    _ = benchmark(write_model_nocheckts, conn=conn, ml=ml)
-
-
-@pytest.mark.benchmark(group="write_model")
-@requires_pkg("pystore")
-def test_benchmark_write_model_nocheckts_pystore(benchmark):
-    path = "./tests/data/pystore"
-    conn = pst.PystoreConnector("test", path)
-    ml = build_model(conn)
-    _ = benchmark(write_model_nocheckts, conn=conn, ml=ml)
-
-
-@pytest.mark.benchmark(group="write_model")
-@requires_pkg("arctic")
-def test_benchmark_write_model_nocheckts_arctic(benchmark):
-    connstr = "mongodb://localhost:27017/"
-    conn = pst.ArcticConnector("test", connstr)
     ml = build_model(conn)
     _ = benchmark(write_model_nocheckts, conn=conn, ml=ml)
 
@@ -233,24 +165,6 @@ def test_benchmark_read_model_pas(benchmark):
     conn = pst.PasConnector("test", "./tests/data/pas")
     _ = benchmark(read_model, conn=conn)
     pst.util.delete_pas_connector(conn)
-
-
-@pytest.mark.benchmark(group="read_model")
-@requires_pkg("pystore")
-def test_benchmark_read_model_pystore(benchmark):
-    path = "./tests/data/pystore"
-    conn = pst.PystoreConnector("test", path)
-    _ = benchmark(read_model, conn=conn)
-    pst.util.delete_pystore_connector(conn=conn)
-
-
-@pytest.mark.benchmark(group="read_model")
-@requires_pkg("arctic")
-def test_benchmark_read_model_arctic(benchmark):
-    connstr = "mongodb://localhost:27017/"
-    conn = pst.ArcticConnector("test", connstr)
-    _ = benchmark(read_model, conn=conn)
-    pst.util.delete_arctic_connector(conn=conn)
 
 
 @pytest.mark.benchmark(group="read_model")


### PR DESCRIPTION
Use `pst.PasConnector` and `pst.ArcticDBConnector` instead

Pystore package is no longer actively maintained, Arctic has been effectively replaced by ArcticDB.