### PR TITLE
PasConnector returns Series and maintains series dtype

### DIFF
--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -1251,7 +1251,7 @@ class ConnectorUtil:
         return meta
 
     def _parse_model_dict(self, mdict: dict, update_ts_settings: bool = False):
-        """Internal method to parse dictionary describing pastas models.
+        """Parse dictionary describing pastas models (internal method).
 
         Parameters
         ----------
@@ -1276,7 +1276,7 @@ class ConnectorUtil:
             if name not in self.oseries.index:
                 msg = "oseries '{}' not present in library".format(name)
                 raise LookupError(msg)
-            mdict["oseries"]["series"] = self.get_oseries(name)
+            mdict["oseries"]["series"] = self.get_oseries(name).squeeze()
             # update tmin/tmax from time series
             if update_ts_settings:
                 mdict["oseries"]["settings"]["tmin"] = mdict["oseries"]["series"].index[
@@ -1296,7 +1296,7 @@ class ConnectorUtil:
                         if "series" not in stress:
                             name = str(stress["name"])
                             if name in self.stresses.index:
-                                stress["series"] = self.get_stresses(name)
+                                stress["series"] = self.get_stresses(name).squeeze()
                                 # update tmin/tmax from time series
                                 if update_ts_settings:
                                     stress["settings"]["tmin"] = stress["series"].index[
@@ -1311,7 +1311,7 @@ class ConnectorUtil:
                         if "series" not in stress:
                             name = str(stress["name"])
                             if name in self.stresses.index:
-                                stress["series"] = self.get_stresses(name)
+                                stress["series"] = self.get_stresses(name).squeeze()
                                 # update tmin/tmax from time series
                                 if update_ts_settings:
                                     stress["settings"]["tmin"] = stress["series"].index[
@@ -1327,7 +1327,7 @@ class ConnectorUtil:
                     if "series" not in stress:
                         name = str(stress["name"])
                         if name in self.stresses.index:
-                            stress["series"] = self.get_stresses(name)
+                            stress["series"] = self.get_stresses(name).squeeze()
                             # update tmin/tmax from time series
                             if update_ts_settings:
                                 stress["settings"]["tmin"] = stress["series"].index[0]
@@ -1717,23 +1717,27 @@ class ConnectorUtil:
             archive.writestr(f"models/{n}.pas", jsondict)
 
     @staticmethod
-    def _series_from_json(fjson: str):
+    def _series_from_json(fjson: str, squeeze: bool = True):
         """Load time series from JSON.
 
         Parameters
         ----------
         fjson : str
             path to file
+        squeeze : bool, optional
+            squeeze time series object to obtain pandas Series
 
         Returns
         -------
         s : pd.DataFrame
             DataFrame containing time series
         """
-        s = pd.read_json(fjson, orient="columns", precise_float=True)
+        s = pd.read_json(fjson, orient="columns", precise_float=True, dtype=False)
         if not isinstance(s.index, pd.DatetimeIndex):
             s.index = pd.to_datetime(s.index, unit="ms")
         s = s.sort_index()  # needed for some reason ...
+        if squeeze:
+            return s.squeeze()
         return s
 
     @staticmethod

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -312,6 +312,9 @@ class BaseConnector(ABC):
         self._validate_input_series(series)
         series = self._set_series_name(series, name)
         stored = self._get_series(libname, name, progressbar=False)
+        if self.conn_type == "pas" and (type(series) != type(stored)):
+            if isinstance(series, pd.DataFrame):
+                stored = stored.to_frame()
         # get union of index
         idx_union = stored.index.union(series.index)
         # update series with new values

--- a/pastastore/yaml_interface.py
+++ b/pastastore/yaml_interface.py
@@ -179,7 +179,7 @@ class PastastoreYAML:
         self.pstore = pstore
 
     def _parse_rechargemodel_dict(self, d: Dict, onam: Optional[str] = None) -> Dict:
-        """Internal method to parse RechargeModel dictionary.
+        """Parse RechargeModel dictionary (internal method).
 
         Note: supports 'nearest' as input to 'prec' and 'evap',
         which will automatically select nearest stress with kind="prec" or
@@ -206,7 +206,7 @@ class PastastoreYAML:
         if isinstance(prec_val, dict):
             pnam = prec_val["name"]
             p = self.pstore.get_stresses(pnam)
-            prec_val["series"] = p
+            prec_val["series"] = p.squeeze()
             prec = prec_val
         elif prec_val.startswith("nearest"):
             if onam is None:
@@ -222,7 +222,7 @@ class PastastoreYAML:
                 "name": pnam,
                 "settings": "prec",
                 "metadata": pmeta,
-                "series": p,
+                "series": p.squeeze(),
             }
         elif isinstance(prec_val, str):
             pnam = d["prec"]
@@ -231,7 +231,7 @@ class PastastoreYAML:
                 "name": pnam,
                 "settings": "prec",
                 "metadata": pmeta,
-                "series": p,
+                "series": p.squeeze(),
             }
         else:
             raise NotImplementedError(f"Could not parse prec value: '{prec_val}'")
@@ -242,7 +242,7 @@ class PastastoreYAML:
         if isinstance(evap_val, dict):
             enam = evap_val["name"]
             e = self.pstore.get_stresses(enam)
-            evap_val["series"] = e
+            evap_val["series"] = e.squeeze()
             evap = evap_val
         elif evap_val.startswith("nearest"):
             if onam is None:
@@ -258,7 +258,7 @@ class PastastoreYAML:
                 "name": enam,
                 "settings": "evap",
                 "metadata": emeta,
-                "series": e,
+                "series": e.squeeze(),
             }
         elif isinstance(evap_val, str):
             enam = d["evap"]
@@ -267,7 +267,7 @@ class PastastoreYAML:
                 "name": enam,
                 "settings": "evap",
                 "metadata": emeta,
-                "series": e,
+                "series": e.squeeze(),
             }
         else:
             raise NotImplementedError(f"Could not parse evap value: '{evap_val}'")
@@ -308,7 +308,7 @@ class PastastoreYAML:
             onam = d["oseries"]
             if isinstance(onam, str):
                 o = self.pstore.get_oseries(onam)
-                d["oseries"] = o
+                d["oseries"] = o.squeeze()
 
         return d
 
@@ -488,7 +488,7 @@ class PastastoreYAML:
         o, ometa = self.pstore.get_oseries(onam, return_metadata=True)
 
         # create model to obtain default model settings
-        ml = ps.Model(o, name=mlnam, metadata=ometa)
+        ml = ps.Model(o.squeeze(), name=mlnam, metadata=ometa)
         mldict = ml.to_dict(series=True)
 
         # update with stored model settings


### PR DESCRIPTION
When loading a time series from disk using PasConnector as database, the dtype would sometimes be returned as int instead of float (which is what was stored initially). This has been fixed wit this PR. 

Additionally, PasConnector does not support maintaining type for Series or DataFrames. You can store both, but now the loading behavior has changed. Before PasConnector would always return a pandas.DataFrame with a single column. Now it will only return a pandas.Series. This makes more sense as that is also what Pastas prefers.

Fixes #119 