### PR TITLE
fix to install extensions

### DIFF
--- a/pastastore/__init__.py
+++ b/pastastore/__init__.py
@@ -1,5 +1,5 @@
 # ruff: noqa: F401 D104
-from pastastore import connectors, styling, util
+from pastastore import connectors, extensions, styling, util
 from pastastore.connectors import (
     ArcticDBConnector,
     DictConnector,

--- a/pastastore/version.py
+++ b/pastastore/version.py
@@ -9,7 +9,7 @@ PASTAS_VERSION = parse_version(ps.__version__)
 PASTAS_LEQ_022 = PASTAS_VERSION <= parse_version("0.22.0")
 PASTAS_GEQ_150 = PASTAS_VERSION >= parse_version("1.5.0")
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 
 def show_versions(optional=False) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,6 @@ docs = [
     "nbsphinx_link",
 ]
 
-[tool.setuptools]
-packages = ["pastastore"]
-
 [tool.setuptools.dynamic]
 version = { attr = "pastastore.version.__version__" }
 


### PR DESCRIPTION
Extensions were not installed because packagedata was set to strictly in pyproject.toml

This fixes that.