### PR TITLE
Add methods for getting nearest knmi time series

### DIFF
--- a/pastastore/extensions/hpd.py
+++ b/pastastore/extensions/hpd.py
@@ -199,6 +199,34 @@ class HydroPandasExtension:
         else:
             raise ValueError("libname must be 'oseries' or 'stresses'.")
 
+    def _get_tmin_tmax(self, tmin, tmax, oseries=None):
+        """Get tmin and tmax from store if not specified.
+
+        Parameters
+        ----------
+        tmin : TimeType
+            start time
+        tmax : TimeType
+            end time
+        oseries : str, optional
+            name of the observation series to get tmin/tmax for, by default None
+
+        Returns
+        -------
+        tmin, tmax : TimeType, TimeType
+            tmin and tmax
+        """
+        # get tmin/tmax if not specified
+        if tmin is None or tmax is None:
+            tmintmax = self._store.get_tmin_tmax(
+                "oseries", names=[oseries] if oseries else None
+            )
+        if tmin is None:
+            tmin = tmintmax.loc[:, "tmin"].min() - Timedelta(days=10 * 365)
+        if tmax is None:
+            tmax = tmintmax.loc[:, "tmax"].max()
+        return tmin, tmax
+
     def download_knmi_precipitation(
         self,
         stns: Optional[list[int]] = None,

--- a/pastastore/extensions/hpd.py
+++ b/pastastore/extensions/hpd.py
@@ -580,6 +580,17 @@ class HydroPandasExtension:
         **kwargs : dict, optional
             Additional keyword arguments to pass to `hpd.read_knmi()`
         """
+        if "source" not in self._store.stresses.columns:
+            msg = (
+                "Cannot update KNMI stresses! "
+                "KNMI stresses cannot be identified if 'source' column is not defined."
+            )
+            logger.error(msg)
+            if raise_on_error:
+                raise ValueError(msg)
+            else:
+                return
+
         if names is None:
             names = self._store.stresses.loc[
                 self._store.stresses["source"] == "KNMI"

--- a/pastastore/extensions/hpd.py
+++ b/pastastore/extensions/hpd.py
@@ -227,6 +227,32 @@ class HydroPandasExtension:
             tmax = tmintmax.loc[:, "tmax"].max()
         return tmin, tmax
 
+    @staticmethod
+    def _normalize_datetime_index(obs):
+        """Normalize observation datetime index (i.e. set observation time to midnight).
+
+        Parameters
+        ----------
+        obs : pandas.Series
+            observation series to normalize
+
+        Returns
+        -------
+        hpd.Obs
+            observation series with normalized datetime index
+        """
+        if isinstance(obs, hpd.Obs):
+            metadata = {k: getattr(obs, k) for k in obs._metadata}
+        else:
+            metadata = {}
+        return obs.__class__(
+            timestep_weighted_resample(
+                obs,
+                obs.index.normalize(),
+            ).rename(obs.name),
+            **metadata,
+        )
+
     def download_knmi_precipitation(
         self,
         stns: Optional[list[int]] = None,
@@ -519,32 +545,6 @@ class HydroPandasExtension:
                 logger.error("Error updating KNMI %s: %s" % (name, str(e)))
                 if raise_on_error:
                     raise e
-
-    @staticmethod
-    def _normalize_datetime_index(obs):
-        """Normalize observation datetime index (i.e. set observation time to midnight).
-
-        Parameters
-        ----------
-        obs : pandas.Series
-            observation series to normalize
-
-        Returns
-        -------
-        hpd.Obs
-            observation series with normalized datetime index
-        """
-        if isinstance(obs, hpd.Obs):
-            metadata = {k: getattr(obs, k) for k in obs._metadata}
-        else:
-            metadata = {}
-        return obs.__class__(
-            timestep_weighted_resample(
-                obs,
-                obs.index.normalize(),
-            ).rename(obs.name),
-            **metadata,
-        )
 
     def download_bro_gmw(
         self,

--- a/pastastore/extensions/hpd.py
+++ b/pastastore/extensions/hpd.py
@@ -331,7 +331,7 @@ class HydroPandasExtension:
             variable to download, by default "RH", valid options are
             e.g. ["RD", "RH", "EV24", "T", "Q"].
         kind : str
-            kind identifier for observations, usually "prec" or "evap".
+            kind identifier for observations in pastastore, usually "prec" or "evap".
         stns : list of int/str, optional
             list of station numbers to download data for, by default None
         tmin : TimeType, optional
@@ -348,12 +348,7 @@ class HydroPandasExtension:
             if True, normalize the datetime so stress value at midnight represents
             the daily total, by default True.
         """
-        # get tmin/tmax if not specified
-        tmintmax = self._store.get_tmin_tmax("oseries")
-        if tmin is None:
-            tmin = tmintmax.loc[:, "tmin"].min() - Timedelta(days=10 * 365)
-        if tmax is None:
-            tmax = tmintmax.loc[:, "tmax"].max()
+        tmin, tmax = self._get_tmin_tmax(tmin, tmax)
 
         if stns is None:
             locations = self._store.oseries.loc[:, ["x", "y"]]

--- a/pastastore/extensions/hpd.py
+++ b/pastastore/extensions/hpd.py
@@ -451,6 +451,7 @@ class HydroPandasExtension:
     def download_nearest_knmi_evaporation(
         self,
         oseries: str,
+        meteo_var: str = "EV24",
         tmin: Optional[TimeType] = None,
         tmax: Optional[TimeType] = None,
         unit_multiplier: float = 1e-3,
@@ -464,6 +465,9 @@ class HydroPandasExtension:
         ----------
         oseries : str
             download nearest evaporation information for this observation well
+        meteo_var : str, optional
+            variable to download, by default "EV24", valid options are:
+            ["EV24", "penman", "hargreaves", "makkink"].
         tmin : TimeType
             start time
         tmax : TimeType
@@ -480,7 +484,7 @@ class HydroPandasExtension:
         """
         self.download_nearest_knmi_meteo(
             oseries=oseries,
-            meteo_var="EV24",
+            meteo_var=meteo_var,
             kind="evap",
             tmin=tmin,
             tmax=tmax,

--- a/pastastore/extensions/hpd.py
+++ b/pastastore/extensions/hpd.py
@@ -164,10 +164,10 @@ class HydroPandasExtension:
         metadata.pop("name", None)
         metadata.pop("meta", None)
         unit = metadata.get("unit", None)
-        if unit == "m" and unit_multiplier == 1e3:
+        if unit == "m" and np.allclose(unit_multiplier, 1e-3):
             metadata["unit"] = "mm"
         elif unit_multiplier != 1.0:
-            metadata["unit"] = f"{unit_multiplier:e}*{unit}"
+            metadata["unit"] = f"{unit_multiplier:.1e}*{unit}"
 
         source = metadata.get("source", "")
         if len(source) > 0:

--- a/pastastore/version.py
+++ b/pastastore/version.py
@@ -9,7 +9,7 @@ PASTAS_VERSION = parse_version(ps.__version__)
 PASTAS_LEQ_022 = PASTAS_VERSION <= parse_version("0.22.0")
 PASTAS_GEQ_150 = PASTAS_VERSION >= parse_version("1.5.0")
 
-__version__ = "1.7.1"
+__version__ = "1.8.0.dev0"
 
 
 def show_versions(optional=False) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ docs = [
     "nbsphinx_link",
 ]
 
+[tool.setuptools.packages]
+find = {}
+
 [tool.setuptools.dynamic]
 version = { attr = "pastastore.version.__version__" }
 

--- a/tests/test_007_hpdextension.py
+++ b/tests/test_007_hpdextension.py
@@ -67,3 +67,19 @@ def test_update_stresses():
     pstore.hpd.update_knmi_meteo(tmax="2024-01-31", normalize_datetime_index=False)
     tmintmax = pstore.get_tmin_tmax("stresses")
     assert (tmintmax["tmax"] >= Timestamp("2024-01-31")).all()
+
+
+@pytest.mark.xfail(reason="KNMI is being flaky, so allow this test to xfail/xpass.")
+@pytest.mark.pastas150
+def test_nearest_stresses():
+    from pastastore.extensions import activate_hydropandas_extension
+
+    activate_hydropandas_extension()
+
+    pstore = pst.PastaStore.from_zip("tests/data/test_hpd_update.zip")
+    pstore.hpd.download_nearest_knmi_precipitation(
+        "GMW000000036319_1", tmin="2024-01-01"
+    )
+    assert "RD_GROOT-AMMERS" in pstore.stresses_names
+    pstore.hpd.download_nearest_knmi_evaporation("GMW000000036319_1", tmin="2024-01-01")
+    assert "EV24_CABAUW-MAST" in pstore.stresses_names


### PR DESCRIPTION
Simple interface to download nearest time series to some stored location. Makes it very easy to build time series models for stored locations based on nearest prec/evap.

```python
pstore  # given some pastastore with stored oseries

# nearest precipitation
pstore.hpd.download_nearest_knmi_precipitation("oseries1")

# nearest evaporation
pstore.hpd.download_nearest_knmi_evaporation("oseries1")

# custom nearest
pstore.hpd.download_nearest_knmi_meteo("oseries1", meteo_var="T", kind="temp")
```