### PR TITLE
Improve error when reading zip-file from pastastore < 1.8.0

### DIFF
--- a/pastastore/store.py
+++ b/pastastore/store.py
@@ -1546,6 +1546,13 @@ class PastaStore:
                 fi for fi in archive.namelist() if not fi.endswith(f"_meta.{ext}")
             ]
             for f in tqdm(namelist, desc="Reading zip") if progressbar else namelist:
+                if f.endswith("_meta.json"):
+                    raise (
+                        ValueError(
+                            "The zipfile was created using pastastore <1.8.0."
+                            " PLease pass `series_ext_json=True` to `from_zip()`"
+                        )
+                    )
                 libname, fjson = os.path.split(f)
                 if libname in ["stresses", "oseries"]:
                     s = pd.read_json(archive.open(f), dtype=float, orient="columns")

--- a/pastastore/store.py
+++ b/pastastore/store.py
@@ -1550,7 +1550,7 @@ class PastaStore:
                     raise (
                         ValueError(
                             "The zipfile was created using pastastore <1.8.0."
-                            " PLease pass `series_ext_json=True` to `from_zip()`"
+                            " Please pass `series_ext_json=True` to `from_zip()`"
                         )
                     )
                 libname, fjson = os.path.split(f)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ documentation = "https://pastastore.readthedocs.io/en/latest/"
 full = ["pastastore[arcticdb,optional]", "hydropandas"]
 extensions = ["hydropandas"]
 optional = ["contextily", "pyproj", "adjustText"]
-arcticdb = ["arcticdb"]
+arcticdb = ["arcticdb", "protobuf >=3.5.0.post1, < 6"]
 lint = ["ruff"]
 pytest = [
     "coverage",


### PR DESCRIPTION
This fix improves the error message when someone wants to read a Pastastore-zipfile from pastastore <1.8.0. The error you would get was:
```
Traceback (most recent call last):

  Cell In[41], line 2
    pstore = pastastore.PastaStore.from_zip(fname)

  File ~\Documents\GitHub\pastastore\pastastore\store.py:1551 in from_zip
    s = pd.read_json(archive.open(f), dtype=float, orient="columns")

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\io\json\_json.py:815 in read_json
    return json_reader.read()

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\io\json\_json.py:1025 in read
    obj = self._get_object_parser(self.data)

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\io\json\_json.py:1051 in _get_object_parser
    obj = FrameParser(json, **kwargs).parse()

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\io\json\_json.py:1187 in parse
    self._parse()

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\io\json\_json.py:1402 in _parse
    self.obj = DataFrame(

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\core\frame.py:778 in __init__
    mgr = dict_to_mgr(data, index, columns, dtype=dtype, copy=copy, typ=manager)

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\core\internals\construction.py:503 in dict_to_mgr
    return arrays_to_mgr(arrays, columns, index, dtype=dtype, typ=typ, consolidate=copy)

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\core\internals\construction.py:114 in arrays_to_mgr
    index = _extract_index(arrays)

  File ~\miniconda3\envs\artesia\Lib\site-packages\pandas\core\internals\construction.py:667 in _extract_index
    raise ValueError("If using all scalar values, you must pass an index")

ValueError: If using all scalar values, you must pass an index

```

After the proposed change the error is:
```
Traceback (most recent call last):

  Cell In[46], line 2
    pstore = pastastore.PastaStore.from_zip(fname)

  File ~\Documents\GitHub\pastastore\pastastore\store.py:1550 in from_zip
    raise (

ValueError: The zipfile was created using pastastore <1.8.0. Please pass `series_ext_json=True` to `from_zip()`
```

Another option would be to automatically set `series_ext_json` to True, but I am not sure if this is what we want. 