### PR TITLE
Add time series protections when time series are used by a stored model

### DIFF
--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -781,7 +781,11 @@ class BaseConnector(ABC):
         self.del_models(names=names, verbose=verbose)
 
     def del_oseries(
-        self, names: Union[list, str], remove_models: bool = False, verbose: bool = True
+        self,
+        names: Union[list, str],
+        remove_models: bool = False,
+        force: bool = False,
+        verbose: bool = True,
     ):
         """Delete oseries from the database.
 
@@ -791,12 +795,14 @@ class BaseConnector(ABC):
             name(s) of the oseries to delete
         remove_models : bool, optional
             also delete models for deleted oseries, default is False
+        force : bool, optional
+            force deletion of oseries that are used in models, by default False
         verbose : bool, optional
             print information about deleted oseries, by default True
         """
         names = self._parse_names(names, libname="oseries")
         for n in names:
-            self._del_item("oseries", n)
+            self._del_item("oseries", n, force=force)
         self._clear_cache("oseries")
         if verbose:
             print(f"Deleted {len(names)} oseries from database.")
@@ -806,23 +812,43 @@ class BaseConnector(ABC):
                 chain.from_iterable([self.oseries_models.get(n, []) for n in names])
             )
             self.del_models(modelnames, verbose=verbose)
+            if verbose:
+                print(f"Deleted {len(modelnames)} models(s) from database.")
 
-    def del_stress(self, names: Union[list, str], verbose: bool = True):
+    def del_stress(
+        self,
+        names: Union[list, str],
+        remove_models: bool = False,
+        force: bool = False,
+        verbose: bool = True,
+    ):
         """Delete stress from the database.
 
         Parameters
         ----------
         names : str or list of str
             name(s) of the stress to delete
+        remove_models : bool, optional
+            also delete models for deleted stresses, default is False
+        force : bool, optional
+            force deletion of stresses that are used in models, by default False
         verbose : bool, optional
             print information about deleted stresses, by default True
         """
         names = self._parse_names(names, libname="stresses")
         for n in names:
-            self._del_item("stresses", n)
+            self._del_item("stresses", n, force=force)
         self._clear_cache("stresses")
         if verbose:
             print(f"Deleted {len(names)} stress(es) from database.")
+        # remove associated models from database
+        if remove_models:
+            modelnames = list(
+                chain.from_iterable([self.stresses_models.get(n, []) for n in names])
+            )
+            self.del_models(modelnames, verbose=verbose)
+            if verbose:
+                print(f"Deleted {len(modelnames)} models(s) from database.")
 
     def _get_series(
         self,

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -1353,10 +1353,24 @@ class BaseConnector(ABC):
                         stresses.append(s.name)
         return list(set(stresses))
 
-        Used for old PastaStore versions, where relationship between oseries and models
-        was not stored. If there are any models in the database and if the
-        oseries_models library is empty, loops through all models to determine which
-        oseries each model belongs to.
+    def _del_stress_model_link(self, stress_names, model_name):
+        """Delete model name from stored list of models per oseries.
+
+        Parameters
+        ----------
+        mldict : dict
+            model dictionary
+        """
+        for stress_name in stress_names:
+            modellist = self._get_item("stresses_models", stress_name)
+            modellist.remove(model_name)
+            if len(modellist) == 0:
+                self._del_item("stresses_models", stress_name)
+            else:
+                self._add_item(
+                    "stresses_models", modellist, stress_name, overwrite=True
+                )
+        self._clear_cache("stresses_models")
         """
         # get oseries_models library if there are any contents, if empty
         # add all model links.

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -392,6 +392,7 @@ class BaseConnector(ABC):
         name: str,
         metadata: Optional[dict] = None,
         validate: Optional[bool] = None,
+        force: bool = False,
     ) -> None:
         """Update time series (internal method).
 
@@ -409,9 +410,14 @@ class BaseConnector(ABC):
         validate: bool, optional
             use pastas to validate series, default is None, which will use the
             USE_PASTAS_VALIDATE_SERIES value (default is True).
+        force : bool, optional
+            force update even if time series is used in a model, by default False
+
         """
         if libname not in ["oseries", "stresses"]:
             raise ValueError("Library must be 'oseries' or 'stresses'!")
+        if not force:
+            self._check_series_in_models(libname, name)
         self._validate_input_series(series)
         series = self._set_series_name(series, name)
         stored = self._get_series(libname, name, progressbar=False)

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -43,6 +43,9 @@ class BaseConnector(ABC):
     # True for pastas>=0.23.0 and False for pastas<=0.22.0
     USE_PASTAS_VALIDATE_SERIES = False if PASTAS_LEQ_022 else True
 
+    # whether to protect series when used by a model
+    PROTECT_SERIES_IN_MODELS = True
+
     # set series equality comparison settings (using assert_series_equal)
     SERIES_EQUALITY_ABSOLUTE_TOLERANCE = 1e-10
     SERIES_EQUALITY_RELATIVE_TOLERANCE = 0.0
@@ -253,6 +256,23 @@ class BaseConnector(ABC):
         self.USE_PASTAS_VALIDATE_SERIES = b
         print(f"Model time series checking set to: {b}.")
 
+    def set_protect_series_in_models(self, b: bool):
+        """Turn PROTECT_SERIES_IN_MODELS option on (True) or off (False).
+
+        The default option is on. When turned on, deleting a time series that
+        is used in a model will raise an error. This prevents models from
+        breaking because a required time series has been deleted. If you really
+        want to delete such a time series, use the force=True option in
+        del_oseries() or del_stress().
+
+        Parameters
+        ----------
+        b : bool
+            boolean indicating whether option should be turned on (True) or
+            off (False). Option is on by default.
+        """
+        self.PROTECT_SERIES_IN_MODELS = b
+        print(f"Protect series in models set to: {b}.")
     def _pastas_validate(self, validate):
         """Whether to validate time series.
 

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -368,6 +368,11 @@ class BaseConnector(ABC):
                 libname, series, name, metadata=metadata, overwrite=overwrite
             )
             self._clear_cache(libname)
+        elif name in self.oseries_models or name in self.stresses_models:
+            raise SeriesUsedByModel(
+                f"Time series with name '{name}' is used by a model! "
+                "Use overwrite=True to replace existing time series."
+            )
         else:
             raise ItemInLibraryException(
                 f"Time series with name '{name}' already in '{libname}' library! "

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -11,9 +11,15 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 import pastas as ps
+from packaging.version import parse as parse_version
 from tqdm.auto import tqdm
 
-from pastastore.util import ItemInLibraryException, _custom_warning, validate_names
+from pastastore.util import (
+    ItemInLibraryException,
+    SeriesUsedByModel,
+    _custom_warning,
+    validate_names,
+)
 from pastastore.version import PASTAS_GEQ_150, PASTAS_LEQ_022
 
 FrameorSeriesUnion = Union[pd.DataFrame, pd.Series]
@@ -126,7 +132,7 @@ class BaseConnector(ABC):
         """
 
     @abstractmethod
-    def _del_item(self, libname: str, name: str) -> None:
+    def _del_item(self, libname: str, name: str, force: bool = False) -> None:
         """Delete items (series or models) (internal method).
 
         Must be overridden by subclass.
@@ -1185,7 +1191,7 @@ class BaseConnector(ABC):
                 if progressbar
                 else names
             ):
-                self._del_item(libname, name)
+                self._del_item(libname, name, force=True)
             self._clear_cache(libname)
             print(f"Emptied library {libname} in {self.name}: {self.__class__}")
 
@@ -1324,6 +1330,7 @@ class BaseConnector(ABC):
                     modellist.append(iml)
             self._add_item("stresses_models", modellist, snam, overwrite=True)
         self._clear_cache("stresses_models")
+
     def _del_oseries_model_link(self, onam, mlnam):
         """Delete model name from stored list of models per oseries.
 

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -1310,7 +1310,7 @@ class BaseConnector(ABC):
             self._add_item("oseries_models", modellist, onam, overwrite=True)
         self._clear_cache("oseries_models")
 
-    def _get_model_stress_names(self, ml: ps.MOdel | dict) -> List[str]:
+    def _get_model_stress_names(self, ml: ps.Model | dict) -> List[str]:
         """Get list of stress names used in model.
 
         Parameters

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -756,6 +756,7 @@ class BaseConnector(ABC):
             oname = mldict["oseries"]["name"]
             self._del_item("models", n)
             self._del_oseries_model_link(oname, n)
+            self._del_stress_model_link(self._get_model_stress_names(mldict), n)
         self._clear_cache("_modelnames_cache")
         if verbose:
             print(f"Deleted {len(names)} model(s) from database.")

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -33,6 +33,7 @@ class BaseConnector(ABC):
         "stresses",
         "models",
         "oseries_models",
+        "stresses_models",
     ]
 
     # whether to check model time series contents against stored copies
@@ -1360,6 +1361,22 @@ class BaseConnector(ABC):
         d = {}
         for onam in self.oseries_with_models:
             d[onam] = self._get_item("oseries_models", onam)
+        return d
+
+    @property  # type: ignore
+    @functools.lru_cache()
+    def stresses_models(self):
+        """List of model names per stress.
+
+        Returns
+        -------
+        d : dict
+            dictionary with oseries names as keys and list of model names as
+            values
+        """
+        d = {}
+        for stress_name in self.stresses_with_models:
+            d[stress_name] = self._get_item("stresses_models", stress_name)
         return d
 
 

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -1384,28 +1384,38 @@ class BaseConnector(ABC):
                 ):
                     self._add_oseries_model_links(onam, mllinks)
 
-    def _get_all_oseries_model_links(self):
-        """Get all model names per oseries in dictionary.
+    def _get_time_series_model_links(self):
+        """Get model names per oseries and stresses time series in a dictionary.
 
         Returns
         -------
         links : dict
-            dictionary with oseries names as keys and lists of model names as
-            values
+            dictionary with 'oseries' and 'stresses' as keys containing
+            dictionaries with time series names as keys and lists of model
+            names as values.
         """
-        links = {}
+        oseries_links = {}
+        stresses_links = {}
         for mldict in tqdm(
             self.iter_models(return_dict=True),
             total=self.n_models,
-            desc="Get models per oseries",
+            desc="Get models per time series",
         ):
-            onam = mldict["oseries"]["name"]
             mlnam = mldict["name"]
-            if onam in links:
-                links[onam].append(mlnam)
+            # oseries
+            onam = mldict["oseries"]["name"]
+            if onam in oseries_links:
+                oseries_links[onam].append(mlnam)
             else:
-                links[onam] = [mlnam]
-        return links
+                oseries_links[onam] = [mlnam]
+            # stresses
+            stress_names = self._get_model_stress_names(mldict)
+            for snam in stress_names:
+                if snam in stresses_links:
+                    stresses_links[snam].append(mlnam)
+                else:
+                    stresses_links[snam] = [mlnam]
+        return {"oseries": oseries_links, "stresses": stresses_links}
 
     @staticmethod
     def _clear_cache(libname: str) -> None:

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -273,6 +273,23 @@ class BaseConnector(ABC):
         """
         self.PROTECT_SERIES_IN_MODELS = b
         print(f"Protect series in models set to: {b}.")
+
+    def _check_series_in_models(self, libname, name):
+        if libname == "oseries":
+            if name in self.oseries_models:
+                n_models = len(self.oseries_models[name])
+                raise SeriesUsedByModel(
+                    f"oseries '{name}' is used in {n_models} model(s)! Either "
+                    "delete model(s) first, or use force=True."
+                )
+        elif libname == "stresses":
+            if name in self.stresses_models:
+                n_models = len(self.stresses_models[name])
+                raise SeriesUsedByModel(
+                    f"stress '{name}' is used in {n_models} model(s)! Either "
+                    "delete model(s) first, or use force=True."
+                )
+
     def _pastas_validate(self, validate):
         """Whether to validate time series.
 

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -66,6 +66,21 @@ class BaseConnector(ABC):
         )
 
     @property
+    def settings(self):
+        """Return current connector settings as dictionary."""
+        return {
+            "CHECK_MODEL_SERIES_VALUES": self.CHECK_MODEL_SERIES_VALUES,
+            "USE_PASTAS_VALIDATE_SERIES": self.USE_PASTAS_VALIDATE_SERIES,
+            "PROTECT_SERIES_IN_MODELS": self.PROTECT_SERIES_IN_MODELS,
+            "SERIES_EQUALITY_ABSOLUTE_TOLERANCE": (
+                self.SERIES_EQUALITY_ABSOLUTE_TOLERANCE
+            ),
+            "SERIES_EQUALITY_RELATIVE_TOLERANCE": (
+                self.SERIES_EQUALITY_RELATIVE_TOLERANCE
+            ),
+        }
+
+    @property
     def empty(self):
         """Check if the database is empty."""
         return not any([self.n_oseries > 0, self.n_stresses > 0, self.n_models > 0])

--- a/pastastore/connectors.py
+++ b/pastastore/connectors.py
@@ -1049,6 +1049,11 @@ class ArcticDBConnector(BaseConnector, ConnectorUtil):
         """List of oseries with models."""
         return self._get_library("oseries_models").list_symbols()
 
+    @property
+    def stresses_with_models(self):
+        """List of stresses with models."""
+        return self._get_library("stresses_models").list_symbols()
+
 
 class DictConnector(BaseConnector, ConnectorUtil):
     """DictConnector object that stores timeseries and models in dictionaries."""
@@ -1114,7 +1119,7 @@ class DictConnector(BaseConnector, ConnectorUtil):
         # check file name for illegal characters
         name = self._check_filename(libname, name)
 
-        if libname in ["models", "oseries_models"]:
+        if libname in ["models", "oseries_models", "stresses_models"]:
             lib[name] = item
         else:
             lib[name] = (metadata, item)
@@ -1135,7 +1140,7 @@ class DictConnector(BaseConnector, ConnectorUtil):
             time series or model dictionary
         """
         lib = self._get_library(libname)
-        if libname in ["models", "oseries_models"]:
+        if libname in ["models", "oseries_models", "stresses_models"]:
             item = deepcopy(lib[name])
         else:
             item = deepcopy(lib[name][1])
@@ -1201,6 +1206,12 @@ class DictConnector(BaseConnector, ConnectorUtil):
     def oseries_with_models(self):
         """List of oseries with models."""
         lib = self._get_library("oseries_models")
+        return list(lib.keys())
+
+    @property
+    def stresses_with_models(self):
+        """List of oseries with models."""
+        lib = self._get_library("stresses_models")
         return list(lib.keys())
 
 
@@ -1324,7 +1335,7 @@ class PasConnector(BaseConnector, ConnectorUtil):
             fmodel = os.path.join(lib, f"{name}.pas")
             with open(fmodel, "w") as fm:
                 fm.write(jsondict)
-        # oseries_models list
+        # oseries_models or stresses_models list
         elif isinstance(item, list):
             jsondict = json.dumps(item)
             fname = os.path.join(lib, f"{name}.pas")
@@ -1356,7 +1367,7 @@ class PasConnector(BaseConnector, ConnectorUtil):
             with open(fjson, "r") as ml_json:
                 item = json.load(ml_json, object_hook=pastas_hook)
         # list of models per oseries
-        elif libname == "oseries_models":
+        elif libname in ["oseries_models", "stresses_models"]:
             with open(fjson, "r") as f:
                 item = json.load(f)
         # time series
@@ -1491,4 +1502,10 @@ class PasConnector(BaseConnector, ConnectorUtil):
     def oseries_with_models(self):
         """List of oseries with models."""
         lib = self._get_library("oseries_models")
+        return [i[:-4] for i in os.listdir(lib) if i.endswith(".pas")]
+
+    @property
+    def stresses_with_models(self):
+        """List of stresses with models."""
+        lib = self._get_library("stresses_models")
         return [i[:-4] for i in os.listdir(lib) if i.endswith(".pas")]

--- a/pastastore/plotting.py
+++ b/pastastore/plotting.py
@@ -1485,7 +1485,7 @@ class Maps:
             m_idx = self.pstore.search(libname="models", s=model_names)
         else:
             m_idx = self.pstore.model_names
-        struct = self.pstore.get_model_timeseries_names(progressbar=False).loc[m_idx]
+        struct = self.pstore.get_model_time_series_names(progressbar=False).loc[m_idx]
 
         oseries = self.pstore.oseries
         stresses = self.pstore.stresses

--- a/pastastore/store.py
+++ b/pastastore/store.py
@@ -295,6 +295,28 @@ class PastaStore:
         """
         return self.conn.oseries_with_models
 
+    @property
+    def stresses_models(self):
+        """Return dictionary of models per stress.
+
+        Returns
+        -------
+        dict
+            dictionary containing list of models (values) for each oseries (keys).
+        """
+        return self.conn.stresses_models
+
+    @property
+    def stresses_with_models(self):
+        """Return list of stresses for which models are contained in the database.
+
+        Returns
+        -------
+        list
+            list of stress names for which models are contained in the database.
+        """
+        return self.conn.stresses_with_models
+
     def __repr__(self):
         """Representation string of the object."""
         return f"<PastaStore> {self.name}: \n - " + self.conn.__str__()

--- a/pastastore/util.py
+++ b/pastastore/util.py
@@ -24,6 +24,12 @@ class ItemInLibraryException(Exception):
     pass
 
 
+class SeriesUsedByModel(Exception):
+    """Exception when item is already in library."""
+
+    pass
+
+
 def delete_arcticdb_connector(
     conn=None,
     uri: Optional[str] = None,


### PR DESCRIPTION
Addresses #166

- Similar to the `pstore.oseries_models` dictionary there is now a `pstore.stresses_models` dictionary that contains the list of models that contain a particular stress. 
 - Time series cannot be deleted when in use by a stored model. Similar to overwriting existing stored time series, users should explicitly indicate that this is what they intend to do. 
 - Use `force=True` to force-delete time series or set `PROTECT_SERIES_IN_MODELS ` to False
 - Adding a time series that already exists AND is used by a model will also raise a SeriesUsedByModel` exception instead of the previous `ItemInLibraryException`. You can still use overwrite=True to ignore this check. 

Side note: Theoretically an "append" operation would be legal (since this will not alter a current stored time series), but for simplicity this "update" operation will also raise a `SeriesUsedByModel` exception. We don't currently have a separate route for append operations which would be needed to implement this. Perhaps this could be a new feature request. 