### PR TITLE
Fix inverted existence checks in Validator

### DIFF
--- a/pastastore/validator.py
+++ b/pastastore/validator.py
@@ -389,7 +389,7 @@ class Validator:
             name = str(ml["oseries"]["name"])
         else:
             raise TypeError("Expected pastas.Model or dict!")
-        if self.connector._item_exists("oseries", name):
+        if not self.connector._item_exists("oseries", name):
             msg = (
                 f"Cannot add model '{ml.name}' because oseries '{name}'"
                 " is not contained in store."
@@ -432,7 +432,7 @@ class Validator:
                 else:
                     stresses = sm.stress
                 for s in stresses:
-                    if self.connector._item_exists("stresses", s.name):
+                    if not self.connector._item_exists("stresses", s.name):
                         msg = (
                             f"Cannot add model '{ml.name}' because stress '{s.name}' "
                             "is not contained in store."
@@ -471,7 +471,7 @@ class Validator:
                 else:
                     stresses = []  # for StepModel, LinearTrend
                 for s in stresses:
-                    if self.connector._item_exists("stresses", s["name"]):
+                    if not self.connector._item_exists("stresses", s["name"]):
                         msg = (
                             f"Cannot add model '{ml.name}' because stress '{s['name']}'"
                             " is not contained in store."


### PR DESCRIPTION
Correct logic in pastastore/validator.py so the validator errors only when referenced store items are missing. Three conditions (oseries and stresses checks) were inverted and now use `if not self.connector._item_exists(...)`, ensuring models are only rejected when the required oseries or stress entries are absent from the store.