### PR TITLE
Fix connector issues when loading zip files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,10 @@ jobs:
           [
             "git+https://github.com/pastas/pastas.git@v1.4.0",
             "git+https://github.com/pastas/pastas.git@v1.5.0",
-            "git+https://github.com/pastas/pastas.git@v1.13.2",
+            "git+https://github.com/pastas/pastas.git@v1.14.0",
             "git+https://github.com/pastas/pastas.git@dev",
           ]
         experimental: [false]
-        include:
-          - pastas-version: "git+https://github.com/pastas/pastas.git@dev2"
-            experimental: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -245,7 +245,7 @@ class BaseConnector(ABC, ConnectorUtil):
 
     _conn_type: str | None = None
     _validator: Validator | None = None
-    name: str | None = None 
+    name: str | None = None
 
     def __init__(self):
         self._added_models = []  # internal list of added models used for updating links

--- a/pastastore/base.py
+++ b/pastastore/base.py
@@ -235,18 +235,20 @@ class BaseConnector(ABC, ConnectorUtil):
     BaseConnector. Your class has to override each abstractmethod and property.
     """
 
-    _default_library_names = [
+    _default_library_names = (
         "oseries",
         "stresses",
         "models",
         "oseries_models",
         "stresses_models",
-    ]
+    )
 
     _conn_type: str | None = None
     _validator: Validator | None = None
-    name: str | None = None
-    _added_models = []  # internal list of added models used for updating links
+    name: str | None = None 
+
+    def __init__(self):
+        self._added_models = []  # internal list of added models used for updating links
 
     def __getstate__(self):
         """Return picklable state, stripping Manager objects and proxies.

--- a/pastastore/connectors.py
+++ b/pastastore/connectors.py
@@ -213,6 +213,7 @@ class ArcticDBConnector(BaseConnector, ParallelUtil):
 
         set_config_string("PickledMetadata.LogLevel", "DEBUG")
 
+        super().__init__()
         self.uri = uri
         self.name = name
 

--- a/pastastore/store.py
+++ b/pastastore/store.py
@@ -1627,6 +1627,11 @@ class PastaStore:
                 archive.extractall(conn.path)
             if storename is None:
                 storename = conn.name
+            # because of the short-circuit, the model cache and reverse lookup tables
+            # are not aware of the extracted models. Guarantee the update of the 
+            # connector here to ensure everything is recomputed.
+            conn._clear_cache("_modelnames_cache")
+            conn._update_time_series_model_links(recompute=True)
             return cls(conn, storename)
 
         with ZipFile(fname, "r") as archive:

--- a/pastastore/store.py
+++ b/pastastore/store.py
@@ -1628,7 +1628,7 @@ class PastaStore:
             if storename is None:
                 storename = conn.name
             # because of the short-circuit, the model cache and reverse lookup tables
-            # are not aware of the extracted models. Guarantee the update of the 
+            # are not aware of the extracted models. Guarantee the update of the
             # connector here to ensure everything is recomputed.
             conn._clear_cache("_modelnames_cache")
             conn._update_time_series_model_links(recompute=True)


### PR DESCRIPTION
- DictConnector was failing because it "remembered" _added_model lists from older instances because I defined a mutable attribute at the class level instead of in __init__.
- PasConnector was failing because it did not realize the zip unpacking had placed data in its folders. Now a resync is forced so it is aware of all the data that was unzipped. 