### PR TITLE
fix datetime units

### DIFF
--- a/pastastore/connectors.py
+++ b/pastastore/connectors.py
@@ -932,17 +932,17 @@ class PasConnector(BaseConnector, ParallelUtil):
         if isinstance(item, pd.Series):
             item = item.to_frame()
         if isinstance(item, pd.DataFrame):
-            if type(item) is pd.DataFrame:
-                sjson = item.to_json(orient="columns")
-            else:
-                # workaround for subclasses of DataFrame that override to_json,
-                # looking at you hydropandas...
-                sjson = pd.DataFrame(item).to_json(orient="columns")
             if name.endswith("_meta"):
                 raise ValueError(
                     "Time series name cannot end with '_meta'. "
                     "Please use a different name for your time series."
                 )
+            if type(item) is pd.DataFrame:
+                sjson = item.to_json(orient="columns", date_unit="ms")
+            else:
+                # workaround for subclasses of DataFrame that override to_json,
+                # looking at you hydropandas...
+                sjson = pd.DataFrame(item).to_json(orient="columns", date_unit="ms")
             fname = lib / f"{name}.pas"
             with fname.open("w", encoding="utf-8") as f:
                 logger.debug("Writing time series '%s' to disk at '%s'.", name, fname)

--- a/pastastore/validator.py
+++ b/pastastore/validator.py
@@ -8,7 +8,7 @@ import warnings
 from pathlib import Path
 
 # import weakref
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import pandas as pd
 import pastas as ps
@@ -440,6 +440,7 @@ class Validator:
                     rtol=self.SERIES_EQUALITY_RELATIVE_TOLERANCE,
                     check_freq=False,
                     check_names=False,
+                    check_index_type=False,
                 )
             except AssertionError as e:
                 raise ValueError(
@@ -488,6 +489,7 @@ class Validator:
                                 rtol=self.SERIES_EQUALITY_RELATIVE_TOLERANCE,
                                 check_freq=False,
                                 check_names=False,
+                                check_index_type=False,
                             )
                         except AssertionError as e:
                             raise ValueError(
@@ -572,3 +574,22 @@ class Validator:
                 raise SeriesUsedByModel(
                     msg.format(libname=libname, name=name, n_models=n_models)
                 )
+
+    def series_index_unit(self, series, unit: Literal["ms", "us", "ns"] = "ms"):
+        """Ensure series index is in specified unit (internal method).
+
+        Parameters
+        ----------
+        series : pandas.Series or pandas.DataFrame
+            time series to check
+        unit : str, optional
+            unit to convert index to (default: 'ms' for milliseconds)
+
+        Returns
+        -------
+        pandas.Series or pandas.DataFrame
+            time series with index in given unit (default: milliseconds)
+        """
+        if series.index.unit != unit:
+            series.index = series.index.as_unit(unit)
+        return series


### PR DESCRIPTION
- use "ms" for pastastore JSON files since older Pandas versions ignore the index_unit when writing JSON and default to "ms"
- add a validator check, but not used yet (might do so once pandas pin enforces >3.0?).
- do not check datetime index unit when comparing two time series